### PR TITLE
Fixes #44

### DIFF
--- a/lib/network/outgoing/peer.go
+++ b/lib/network/outgoing/peer.go
@@ -50,3 +50,9 @@ func (p *Peer) RefreshConnection() {
 	p.Disconnect()
 	p.Connect()
 }
+
+// SendCommand Handles sending a command to a remote node. Command is like this
+// "hash:Command"
+func (p *Peer) SendCommand(Command string) {
+	(*p.Conn).Write([]byte(Command))
+}

--- a/lib/network/outgoing/requester/requester.go
+++ b/lib/network/outgoing/requester/requester.go
@@ -3,6 +3,7 @@ package requester
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"github.com/GrappigPanda/Olivia/lib/network/outgoing"
 	. "github.com/GrappigPanda/Olivia/lib/network/outgoing/message_handler"
 	"github.com/GrappigPanda/Olivia/lib/network/outgoing/receiver"
@@ -14,11 +15,14 @@ import (
 func SendRequest(peer *peer.Peer, Command string, responseChannel chan string, mh *MessageHandler) {
 	receiver := network_receiver.NewReceiver(mh, peer.Conn)
 
-	addCommandToMessageHandler(hashRequest(Command), responseChannel, mh)
+	hash := hashRequest(Command)
+	addCommandToMessageHandler(hash, responseChannel, mh)
 
 	go func() {
 		receiver.Run()
 	}()
+
+	(*peer.Conn).Write([]byte(fmt.Sprintf("%s:%s", hash, Command)))
 }
 
 // addCommandToMessageHandler send a command to the message container to store

--- a/lib/network/outgoing/requester/requester_test.go
+++ b/lib/network/outgoing/requester/requester_test.go
@@ -1,0 +1,24 @@
+package requester
+
+import (
+	"github.com/GrappigPanda/Olivia/lib/network/outgoing/message_handler"
+	"testing"
+)
+
+func TestaddCommandToMessageHandler(t *testing.T) {
+	hash := hashRequest("testmd5")
+	ch := make(chan string)
+	mh := message_handler.NewMessageHandler()
+	addCommandToMessageHandler(hash, ch, mh)
+}
+
+// Oh, the things we'll do for those sweet, sweet coverage points
+func TesthashRequest(t *testing.T) {
+	expectedReturn := "32269AE63A25306BB46A03D6F38BD2B7"
+	hash := hashRequest("testmd5")
+
+	if hash != expectedReturn {
+		t.Fatalf("Google has somehow managed to break md5. Abandon Go.")
+	}
+
+}


### PR DESCRIPTION
ADD:
- requester/requester.go A new class which handles sending requests to remote
  nodes.
- requester_test.go Added unit tests for helper methods.
- peer.go Adding a `SendCommand` function so that the requester doesn't need
  to derefernce the `Conn` object in a `Peer`.
