### PR TITLE
Fixes #52

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,6 +1,31 @@
 package cache
 
+import (
+	"fmt"
+)
+
 // TODO(ian): Replace this with something else
 type Cache struct {
 	Cache *map[string]string
+}
+
+func NewCache() *Cache {
+	cacheMap := make(map[string]string)
+	return &Cache{
+		&cacheMap,
+	}
+}
+
+func (c *Cache) Get(key string) (string, error) {
+	var value string = ""
+	if value, ok := (*c.Cache)[key]; !ok {
+		return value, fmt.Errorf("Key not found in cache")
+	}
+
+	return value, nil
+}
+
+func (c *Cache) Set(key string, value string) error {
+	(*c.Cache)[key] = value
+	return nil
 }

--- a/lib/network/incoming/incoming_network.go
+++ b/lib/network/incoming/incoming_network.go
@@ -20,23 +20,18 @@ type ConnectionCtx struct {
 
 // StartNetworkRouter initializes everything necessary for our incoming network
 // router to process and begins our network router.
-func StartNetworkRouter(mh *message_handler.MessageHandler) {
+func StartNetworkRouter(mh *message_handler.MessageHandler, cache *cache.Cache) {
 	listen, err := net.Listen("tcp", ":5454")
 	if err != nil {
 		panic(err)
 	}
 	defer listen.Close()
 
-	_cache := make(map[string]string)
-	cache := cache.Cache{
-		&_cache,
-	}
-
 	bf := olilib.NewByFailRate(10000, 0.01)
 
 	ctx := &ConnectionCtx{
 		queryLanguage.NewParser(mh),
-		&cache,
+		cache,
 		bf,
 	}
 

--- a/lib/network/network_handler.go
+++ b/lib/network/network_handler.go
@@ -1,6 +1,7 @@
 package networkHandler
 
 import (
+	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/lib/network/incoming"
 	"github.com/GrappigPanda/Olivia/lib/network/message_handler"
 )
@@ -8,6 +9,6 @@ import (
 // StartIncomingNetwork handles spinning up an incoming network router and
 // doing any error checking (in the future) as well as ensuring that it
 // continues running.
-func StartIncomingNetwork(mh *message_handler.MessageHandler) {
-	incomingNetwork.StartNetworkRouter(mh)
+func StartIncomingNetwork(mh *message_handler.MessageHandler, cache *cache.Cache) {
+	go incomingNetwork.StartNetworkRouter(mh, cache)
 }

--- a/main.go
+++ b/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/lib/network"
 	"github.com/GrappigPanda/Olivia/lib/network/message_handler"
 )
 
 func Init() {
+	internalCache := cache.NewCache()
+
 	messageHandler := message_handler.NewMessageHandler()
-	go networkHandler.StartIncomingNetwork(messageHandler)
+	networkHandler.StartIncomingNetwork(messageHandler, internalCache)
 }
 
 func main() {
+	Init()
 }


### PR DESCRIPTION
CHANGE:
- incoming_network.go Is now aware of the internal cache and uses it instead
  of creating one whenever the network router is created.
- network_handler.go Now receives the cache after being called from the
  program's entry point.
