### PR TITLE
Fixes #60

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Olivia
 .idea*
 .idea
 .idea/*
+Olivia.exe

--- a/lib/chord/peer.go
+++ b/lib/chord/peer.go
@@ -49,7 +49,7 @@ func NewPeer(conn *net.Conn, mh *message_handler.MessageHandler) *Peer {
 func (p *Peer) Connect() error {
 	conn, err := net.DialTimeout("tcp", p.ipPort, 5*time.Second)
 	if err != nil {
-		if err, ok := err.(net.Error); ok && err.Timeout() {
+		if err, _ := err.(net.Error); err.Timeout() {
 			p.Status = Timeout
 		}
 		return err

--- a/lib/chord/peerlist.go
+++ b/lib/chord/peerlist.go
@@ -1,6 +1,7 @@
 package chord
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -20,12 +21,21 @@ func NewPeerList() *PeerList {
 }
 
 // ConnectAllPeers connects all peers (or at least attempts to)
-func (p *PeerList) ConnectAllPeers() {
+func (p *PeerList) ConnectAllPeers() error {
+	failureCount := 0
 	for x := range p.Peers {
 		if err := p.Peers[x].Connect(); err != nil {
 			log.Println(err)
+			failureCount++
 		}
 	}
+
+	if failureCount == len(p.Peers) {
+		log.Println("Failed to connect to any nodes.")
+		return fmt.Errorf("No connectable nodes.")
+	}
+
+	return nil
 }
 
 // DisconnectAllPeers disconnects all peers

--- a/lib/network/network_handler.go
+++ b/lib/network/network_handler.go
@@ -1,6 +1,8 @@
 package networkHandler
 
 import (
+	"log"
+	"time"
 	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/lib/network/incoming"
 	"github.com/GrappigPanda/Olivia/lib/network/message_handler"
@@ -10,8 +12,15 @@ import (
 // StartIncomingNetwork handles spinning up an incoming network router and
 // doing any error checking (in the future) as well as ensuring that it
 // continues running.
-func StartIncomingNetwork(mh *message_handler.MessageHandler, cache *cache.Cache) {
+func StartIncomingNetwork(
+	mh *message_handler.MessageHandler,
+	cache *cache.Cache,
+) {
 	peerList := chord.NewPeerList()
+	if err := peerList.ConnectAllPeers(); err != nil {
+		log.Println("Sleeping for 60 seconds and attempting to reconnect")
+		time.Sleep(time.Second * 60)
+	}
 
 	go incomingNetwork.StartNetworkRouter(mh, cache, peerList)
 }


### PR DESCRIPTION
ADD:
- network_handler.go/peerlist.go Added error handling for whenever no
  nodes are connectable. It now cycles into a 60 second refresh time.
