### PR TITLE
Fixes #32

### DIFF
--- a/bloomfilter/bloom.go
+++ b/bloomfilter/bloom.go
@@ -64,7 +64,8 @@ func (bf *BloomFilter) HasKey(key []byte) (bool, []uint64) {
 	return true, hashIndexes
 }
 
-// ConvertToString handles conversion of a bloom filter to a string.
+// ConvertToString handles conversion of a bloom filter to a string. Moreover,
+// it enforces RLE encoding, so that fewer bytes are transferred per request.
 func (bf *BloomFilter) ConvertToString() string {
 	var buffer bytes.Buffer
 
@@ -75,13 +76,17 @@ func (bf *BloomFilter) ConvertToString() string {
 	return buffer.String()
 }
 
+// ConvertStringToBF Decodes the RLE'd bloom filter and then converts it to
+// an actual bloom filter in-memory.
 func ConvertStringtoBF(inputString string) (*BloomFilter, error) {
 	// TODO(ian): Remove this magic number.
-	bf := NewByFailRate(10000, 0.01)
+	bf := NewByFailRate(1000, 0.01)
+
+	decodedString := inputString
 
 	index := 0
-	for i, _ := range inputString {
-		number, err := strconv.ParseInt(string(inputString[i]), 10, 0)
+	for i, _ := range decodedString {
+		number, err := strconv.ParseInt(string(decodedString[i]), 10, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/bloomfilter/bloom.go
+++ b/bloomfilter/bloom.go
@@ -73,7 +73,7 @@ func (bf *BloomFilter) ConvertToString() string {
 		buffer.WriteString(fmt.Sprintf("%v", bf.Filter[i]))
 	}
 
-	return buffer.String()
+	return Encode(buffer.String())
 }
 
 // ConvertStringToBF Decodes the RLE'd bloom filter and then converts it to
@@ -82,7 +82,7 @@ func ConvertStringtoBF(inputString string) (*BloomFilter, error) {
 	// TODO(ian): Remove this magic number.
 	bf := NewByFailRate(1000, 0.01)
 
-	decodedString := inputString
+	decodedString := Decode(inputString)
 
 	index := 0
 	for i, _ := range decodedString {

--- a/bloomfilter/bloom_test.go
+++ b/bloomfilter/bloom_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestNewBloomFilter(t *testing.T) {
 	expectedReturn := BloomFilter{
-		MaxSize:       10000,
+		MaxSize:       1000,
 		HashFunctions: 3,
-		Filter:        make([]int, 10000),
+		Filter:        make([]int, 1000),
 	}
 
-	result := New(10000, 3)
+	result := New(1000, 3)
 
 	if expectedReturn.MaxSize != result.MaxSize {
 		t.Fatalf("Expected %v got %v", expectedReturn.MaxSize, result.MaxSize)
@@ -24,12 +24,12 @@ func TestNewBloomFilter(t *testing.T) {
 
 func TestNewBloomFilterByFailRate(t *testing.T) {
 	expectedReturn := BloomFilter{
-		MaxSize:       95850,
+		MaxSize:       9585,
 		HashFunctions: 3,
-		Filter:        make([]int, 10000),
+		Filter:        make([]int, 1000),
 	}
 
-	result := NewByFailRate(10000, 0.01)
+	result := NewByFailRate(1000, 0.01)
 
 	if expectedReturn.MaxSize != result.MaxSize {
 		t.Fatalf("Expected %v got %v", expectedReturn.MaxSize, result.MaxSize)
@@ -37,7 +37,7 @@ func TestNewBloomFilterByFailRate(t *testing.T) {
 }
 
 func TestAddKey(t *testing.T) {
-	bf := NewByFailRate(10000, 0.01)
+	bf := NewByFailRate(1000, 0.01)
 
 	addKeyRet, addIndexes := bf.AddKey([]byte("TestKey"))
 	hasKeyRet, hasIndexes := bf.HasKey([]byte("TestKey"))
@@ -58,7 +58,7 @@ func TestAddKey(t *testing.T) {
 }
 
 func TestHasKeyFailNoKey(t *testing.T) {
-	bf := NewByFailRate(10000, 0.01)
+	bf := NewByFailRate(1000, 0.01)
 
 	hasKeyRet, _ := bf.HasKey([]byte("TestKey"))
 
@@ -68,7 +68,7 @@ func TestHasKeyFailNoKey(t *testing.T) {
 }
 
 func TestConvertToString(t *testing.T) {
-	bf := NewByFailRate(10000, 0.01)
+	bf := NewByFailRate(1000, 0.01)
 
 	new_bf_str := bf.ConvertToString()
 
@@ -85,7 +85,7 @@ func TestConvertToString(t *testing.T) {
 }
 
 func TestConvertWithContainedValues(t *testing.T) {
-	bf := NewByFailRate(10000, 0.01)
+	bf := NewByFailRate(1000, 0.01)
 
 	bf.AddKey([]byte("keyalksdjfl"))
 	bf.AddKey([]byte("key1"))

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -59,17 +59,6 @@ func Encode(inputString string) string {
 	return output
 }
 
-// writeOutput is just a simple helper method for Encode which sprintfs the
-// output string
-func writeOutput(outputString string, char byte, count int) string {
-	return fmt.Sprintf(
-		"%s%s%d",
-		outputString,
-		string(char),
-		count,
-	)
-}
-
 // Decode essentially works opposite of Encode and turns and encoded string
 // into a normal, usable string.
 func Decode(encodedString string) string {
@@ -79,23 +68,88 @@ func Decode(encodedString string) string {
 
 	var output string
 
-	for i := 0; i < len(encodedString); i += 2 {
+	for i := 0; i < len(encodedString) - 1; {
 		repeatCount, err := strconv.Atoi(string(encodedString[i + 1]))
 		if err != nil {
-			// If we encounter an error, say screw it and skip the
-			// character and its count.
-			continue
+			repeatCount = 1
 		}
 
-		output = fmt.Sprintf(
-			"%s%s",
-			output,
-			strings.Repeat(
-				string(encodedString[i]),
-				repeatCount,
-			),
-		)
+		output = writeRepeat(output, encodedString[i], repeatCount)
+
+		if repeatCount == 1 {
+			i++
+		} else {
+			i += 2
+		}
 	}
 
 	return output
+}
+
+// Handles decoding run length encoded integers. Huge pain in the ass overall.
+func DecodeInteger(encodedString string) string {
+	return ""
+}
+
+// writeOutput is just a simple helper method for Encode which sprintfs the
+// output string
+func writeOutput(outputString string, char byte, count int) string {
+	var retVal string
+
+	if count == 1 {
+		return fmt.Sprintf(
+			"%s%s",
+			outputString,
+			string(char),
+		)
+	} else if count > 9 {
+		number := "9"
+		for x := 0; x <= count / 9; x++ {
+			if x == count / 9  && count % 9 != 0{
+				number = strconv.Itoa(count % 9)
+			} else if x == count / 9 {
+				break
+			}
+			retVal = fmt.Sprintf(
+				"%s%s%s",
+				retVal,
+				string(char),
+				number,
+			)
+		}
+	} else {
+		retVal = fmt.Sprintf(
+			"%s%s%d",
+			outputString,
+			string(char),
+			count,
+		)
+	}
+
+	return retVal
+}
+
+// writeRepeat handles writing repeating characters intelligently
+func writeRepeat(output string, char byte, repeat int) string {
+	var retVal string
+
+	// If the next character is an integer, we can encode it.
+	if repeat > 1 {
+		retVal = fmt.Sprintf(
+			"%s%s",
+			output,
+			strings.Repeat(
+				string(char),
+				repeat,
+			),
+		)
+	} else {
+		retVal = fmt.Sprintf(
+			"%s%s",
+			output,
+			string(char),
+		)
+	}
+
+	return retVal
 }

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -1,0 +1,101 @@
+package olilib
+
+import (
+	"strconv"
+	"strings"
+	"fmt"
+)
+
+// Encode handles encoding the bloom filter.
+// An example string before encoding: "AAAABBCCCDZZZRTTT"
+// An example string after encoding "A4B2C3D1Z3R1T3".
+// Please note: This could essentially return an inoptimal compression, as if
+// we have a string with alternating single values (i.e., "01010101010101")
+// this RLE encoding will result in a string twice as long.
+// There is an optimization where we only count runs and not single characters,
+// but for the time being, I don't think it's necessary.
+func Encode(inputString string) string {
+	if len(inputString) == 0 {
+		return ""
+	}
+
+	var currentChar byte
+	var count int = 0
+	var output string
+
+	// Iterate through each character in the string. Keep the current
+	// character that we're tracking and the current count. If we reach a
+	// character which is not the currently tracked character, we reset
+	// the currently tracked character and the count. Runs in O(n).
+	for i := range inputString {
+		if i == 0 {
+			currentChar = inputString[i]
+			count++
+			continue
+		}
+
+		if inputString[i] == currentChar {
+			count++
+		} else {
+			output = writeOutput(
+				output,
+				currentChar,
+				count,
+			)
+
+			currentChar = inputString[i]
+			count = 1
+		}
+	}
+
+	// Write it one more time because we hit bounds on ranging inputString.
+	output = writeOutput(
+		output,
+		currentChar,
+		count,
+	)
+
+
+	return output
+}
+
+// writeOutput is just a simple helper method for Encode which sprintfs the
+// output string
+func writeOutput(outputString string, char byte, count int) string {
+	return fmt.Sprintf(
+		"%s%s%d",
+		outputString,
+		string(char),
+		count,
+	)
+}
+
+// Decode essentially works opposite of Encode and turns and encoded string
+// into a normal, usable string.
+func Decode(encodedString string) string {
+	if len(encodedString) == 0 {
+		return ""
+	}
+
+	var output string
+
+	for i := 0; i < len(encodedString); i += 2 {
+		repeatCount, err := strconv.Atoi(string(encodedString[i + 1]))
+		if err != nil {
+			// If we encounter an error, say screw it and skip the
+			// character and its count.
+			continue
+		}
+
+		output = fmt.Sprintf(
+			"%s%s",
+			output,
+			strings.Repeat(
+				string(encodedString[i]),
+				repeatCount,
+			),
+		)
+	}
+
+	return output
+}

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -67,28 +67,27 @@ func Decode(encodedString string) string {
 	}
 
 	var output string
+	var increment bool
 
 	for i := 0; i < len(encodedString) - 1; {
 		repeatCount, err := strconv.Atoi(string(encodedString[i + 1]))
 		if err != nil {
 			repeatCount = 1
+			increment = true
 		}
 
 		output = writeRepeat(output, encodedString[i], repeatCount)
 
-		if repeatCount == 1 {
+		if increment {
 			i++
 		} else {
 			i += 2
 		}
+
+		increment = false
 	}
 
 	return output
-}
-
-// Handles decoding run length encoded integers. Huge pain in the ass overall.
-func DecodeInteger(encodedString string) string {
-	return ""
 }
 
 // writeOutput is just a simple helper method for Encode which sprintfs the
@@ -104,11 +103,12 @@ func writeOutput(outputString string, char byte, count int) string {
 		)
 	} else if count > 9 {
 		number := "9"
+		retVal = outputString
 		for x := 0; x <= count / 9; x++ {
 			if x == count / 9  && count % 9 != 0{
 				number = strconv.Itoa(count % 9)
 			} else if x == count / 9 {
-				break
+				continue
 			}
 			retVal = fmt.Sprintf(
 				"%s%s%s",

--- a/bloomfilter/rle_test.go
+++ b/bloomfilter/rle_test.go
@@ -1,0 +1,60 @@
+package olilib
+
+import (
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	expectedReturn := "A3B2Z5T3"
+	retVal := Encode("AAABBZZZZZTTT")
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
+func TestEncodeIntegers(t *testing.T) {
+	expectedReturn := "052234"
+	retVal := Encode("00000223333")
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+func TestDecode(t *testing.T) {
+	expectedReturn := "AAABBZZZZZTTT"
+	retVal := Decode("A3B2Z5T3")
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
+func TestDencodeIntegers(t *testing.T) {
+	expectedReturn := "00000223333"
+	retVal := Decode("052234")
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
+func TestEncodeDecode(t *testing.T) {
+	expectedReturn := "AAABBZZZZZTTT"
+	retVal := Encode(expectedReturn)
+	retVal = Decode(retVal)
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
+func TestEncodeDecodeIntegers(t *testing.T) {
+	expectedReturn := "00000223333"
+	retVal := Encode(expectedReturn)
+	retVal = Decode(retVal)
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}

--- a/bloomfilter/rle_test.go
+++ b/bloomfilter/rle_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestEncode(t *testing.T) {
-	expectedReturn := "A3B2Z5T3"
-	retVal := Encode("AAABBZZZZZTTT")
+	expectedReturn := "A3BZ5T3"
+	retVal := Encode("AAABZZZZZTTT")
 
 	if expectedReturn != retVal {
 		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
@@ -21,14 +21,34 @@ func TestEncodeIntegers(t *testing.T) {
 		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
 	}
 }
+
 func TestDecode(t *testing.T) {
-	expectedReturn := "AAABBZZZZZTTT"
-	retVal := Decode("A3B2Z5T3")
+	expectedReturn := "AAABZZZZZTTT"
+	retVal := Decode("A3BZ5T3")
 
 	if expectedReturn != retVal {
 		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
 	}
 }
+
+func TestWriteOutputOver9(t *testing.T) {
+	expectedReturn := "a9a9a9a9a9a9a9"
+	retVal := writeOutput("", 'a', 63)
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
+func TestWriteOutputOver9WithExtra(t *testing.T) {
+	expectedReturn := "a9a9a9a9a9a9a9a5"
+	retVal := writeOutput("", 'a', 68)
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
 
 func TestDencodeIntegers(t *testing.T) {
 	expectedReturn := "00000223333"

--- a/lru_cache/binary_heap_test.go
+++ b/lru_cache/binary_heap_test.go
@@ -13,6 +13,7 @@ func TestNewNode(t *testing.T) {
 		timeout: time.Now().UTC(),
 	}
 
+	time.Sleep(5 * time.Millisecond)
 	retVal := NewNode("TestingNewNodeKey", time.Now().UTC())
 
 	if expectedReturn.Key != retVal.Key {

--- a/lru_cache/lru_cache_int64_array_test.go
+++ b/lru_cache/lru_cache_int64_array_test.go
@@ -95,6 +95,7 @@ func TestGetInt64(t *testing.T) {
 
 	node, _ := testLRU.KeyTimeouts.Get("Key1")
 	originalTime := node.timeout
+	time.Sleep(5 * time.Millisecond)
 	value, keyExists := testLRU.Get("Key1")
 
 	if keyExists != true {

--- a/lru_cache/lru_cache_test.go
+++ b/lru_cache/lru_cache_test.go
@@ -88,6 +88,7 @@ func TestGet(t *testing.T) {
 
 	node, _ := testLRU.KeyTimeouts.Get("Key1")
 	originalTime := node.timeout
+	time.Sleep(5 * time.Millisecond)
 	value, keyExists := testLRU.Get("Key1")
 
 	if keyExists != true {

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -35,7 +35,7 @@ func StartNetworkRouter(
 	}
 	defer listen.Close()
 
-	bf := olilib.NewByFailRate(10000, 0.01)
+	bf := olilib.NewByFailRate(1000, 0.01)
 
 	ctx := &ConnectionCtx{
 		parser.NewParser(mh),

--- a/network/incoming/language_map_test.go
+++ b/network/incoming/language_map_test.go
@@ -18,7 +18,7 @@ var CTX = &ConnectionCtx{
 		Cache: &CACHE,
 		ReadCache: &READCACHE,
 	},
-	olilib.NewByFailRate(10000, 0.01),
+	olilib.NewByFailRate(1000, 0.01),
 	message_handler.NewMessageHandler(),
 	dht.NewPeerList(),
 }
@@ -72,7 +72,7 @@ func TestExecuteSetKey(t *testing.T) {
 }
 
 func TestRequestBloomFilter(t *testing.T) {
-	bf := olilib.NewByFailRate(10000, 0.01)
+	bf := olilib.NewByFailRate(1000, 0.01)
 
 	bf.AddKey([]byte("keyalksdjfl"))
 	bf.AddKey([]byte("key1"))


### PR DESCRIPTION
ADD:
- bloomfilter/rle.go A simple implementation of runtime encoding which
  will be used to shorten bytes transferred when copying a bloom filter
  between multiple nodes.
