### PR TITLE
Fixes #79

### DIFF
--- a/lru_cache/lru_cache.go
+++ b/lru_cache/lru_cache.go
@@ -3,6 +3,7 @@ package olilib_lru
 import (
 	"sync"
 	"time"
+	binheap "github.com/GrappigPanda/Olivia/shared"
 )
 
 // MAXINT64 Signifies the maximum value for an int64 in Go
@@ -15,7 +16,7 @@ var MAXINT64 = int64(1<<63 - 1)
 type LRUCacheString struct {
 	KeyCount    int
 	Keys        map[string]string
-	KeyTimeouts *Heap
+	KeyTimeouts *binheap.Heap
 	Mutex       *sync.Mutex
 }
 
@@ -25,7 +26,7 @@ func NewString(maxEntries int) *LRUCacheString {
 	return &LRUCacheString{
 		KeyCount:    maxEntries,
 		Keys:        make(map[string]string),
-		KeyTimeouts: NewHeap(maxEntries),
+		KeyTimeouts: binheap.NewHeap(maxEntries),
 		Mutex:       &sync.Mutex{},
 	}
 }
@@ -60,7 +61,7 @@ func (l *LRUCacheString) Add(key string, value string) (string, bool) {
 // addNewKeyTimeout handles adding a key into our priority queue for later
 // eviction.
 func (l *LRUCacheString) addNewKeyTimeout(key string) {
-	l.KeyTimeouts.Insert(NewNode(key, getCurrentUnixTime()))
+	l.KeyTimeouts.Insert(binheap.NewNode(key, getCurrentUnixTime()))
 }
 
 // Get Retrieves a key from the LRU cache and increases its priority.

--- a/lru_cache/lru_cache_int64_array_test.go
+++ b/lru_cache/lru_cache_int64_array_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	binheap "github.com/GrappigPanda/Olivia/shared"
 )
 
 var TESTLRUINT64 = NewInt64Array(10)
@@ -12,7 +13,7 @@ func TestNewInt64(t *testing.T) {
 	expectedReturn := &LRUCacheInt64Array{
 		10,
 		make(map[string][]uint64, 10),
-		NewHeap(10),
+		binheap.NewHeap(10),
 		&sync.Mutex{},
 	}
 
@@ -94,7 +95,7 @@ func TestGetInt64(t *testing.T) {
 	testLRU.Add("Key1", expectedReturn)
 
 	node, _ := testLRU.KeyTimeouts.Get("Key1")
-	originalTime := node.timeout
+	originalTime := node.Timeout
 	time.Sleep(5 * time.Millisecond)
 	value, keyExists := testLRU.Get("Key1")
 
@@ -108,7 +109,7 @@ func TestGetInt64(t *testing.T) {
 		}
 	}
 
-	if node.timeout == originalTime {
+	if node.Timeout == originalTime {
 		t.Fatalf("Time for retrieving a key didnt update, please fix.")
 	}
 }

--- a/lru_cache/lru_cache_int_array.go
+++ b/lru_cache/lru_cache_int_array.go
@@ -3,6 +3,7 @@ package olilib_lru
 import (
 	"sync"
 	"time"
+	binheap "github.com/GrappigPanda/Olivia/shared"
 )
 
 // LRUCacheInt64Array is a simple implementation of an LRU cache which will be used in
@@ -12,7 +13,7 @@ import (
 type LRUCacheInt64Array struct {
 	KeyCount    int
 	Keys        map[string][]uint64
-	KeyTimeouts *Heap
+	KeyTimeouts *binheap.Heap
 	Mutex       *sync.Mutex
 }
 
@@ -22,7 +23,7 @@ func NewInt64Array(maxEntries int) *LRUCacheInt64Array {
 	return &LRUCacheInt64Array{
 		KeyCount:    maxEntries,
 		Keys:        make(map[string][]uint64),
-		KeyTimeouts: NewHeap(maxEntries),
+		KeyTimeouts: binheap.NewHeap(maxEntries),
 		Mutex:       &sync.Mutex{},
 	}
 }
@@ -49,7 +50,7 @@ func (l *LRUCacheInt64Array) Add(key string, value []uint64) ([]uint64, bool) {
 	}
 
 	l.Keys[key] = value
-	l.KeyTimeouts.Insert(NewNode(key, time.Now().UTC()))
+	l.KeyTimeouts.Insert(binheap.NewNode(key, time.Now().UTC()))
 
 	return value, false
 }

--- a/lru_cache/lru_cache_test.go
+++ b/lru_cache/lru_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	binheap "github.com/GrappigPanda/Olivia/shared"
 )
 
 var TESTLRU = NewString(10)
@@ -12,7 +13,7 @@ func TestNew(t *testing.T) {
 	expectedReturn := &LRUCacheString{
 		10,
 		make(map[string]string, 10),
-		NewHeap(10),
+		binheap.NewHeap(10),
 		&sync.Mutex{},
 	}
 
@@ -87,7 +88,7 @@ func TestGet(t *testing.T) {
 	testLRU.Add("Key1", "value1")
 
 	node, _ := testLRU.KeyTimeouts.Get("Key1")
-	originalTime := node.timeout
+	originalTime := node.Timeout
 	time.Sleep(5 * time.Millisecond)
 	value, keyExists := testLRU.Get("Key1")
 
@@ -99,7 +100,7 @@ func TestGet(t *testing.T) {
 		t.Fatalf("Expected value1, got %v", value)
 	}
 
-	if node.timeout == originalTime {
+	if node.Timeout == originalTime {
 		t.Fatalf("Time for retrieving a key didnt update, please fix.")
 	}
 }

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,8 @@
+# Shared
+
+Mostly what's kept here are generic pieces of code re-used in several places.
+I know this sounds like every other folder, but it's mainly reserved for simple
+pieces of code which don't need to act on their own.
+
+A good example of this is the min binary heap implementation which is used for
+both the LRU cache and for key expiration.

--- a/shared/binary_heap.go
+++ b/shared/binary_heap.go
@@ -1,4 +1,4 @@
-package olilib_lru
+package shared
 
 import (
 	"time"
@@ -16,7 +16,7 @@ const (
 // Node represents each binary heap node.
 type Node struct {
 	Key     string
-	timeout time.Time
+	Timeout time.Time
 }
 
 // Heap represents our binary heap object.
@@ -34,10 +34,10 @@ type Heap struct {
 // NewNode Allocates a new Node. It is not placed in the binary heap at
 // allocation. Rather, the caller is expected to later Insert the newly created
 // node into the binary heap.
-func NewNode(key string, timeout time.Time) *Node {
+func NewNode(key string, Timeout time.Time) *Node {
 	return &Node{
 		Key:     key,
-		timeout: timeout,
+		Timeout: Timeout,
 	}
 }
 
@@ -140,14 +140,14 @@ func (h *Heap) ReAllocate(maxSize int) {
 	h.Tree = append(h.Tree, make([]*Node, maxSize)...)
 }
 
-// UpdateNodeTimeout allows changing of the keys timeout in the
+// UpdateNodeTimeout allows changing of the keys Timeout in the
 func (h *Heap) UpdateNodeTimeout(key string) *Node {
 	nodeIndex, ok := h.keyLookup[key]
 	if !ok {
 		return nil
 	}
 
-	h.Tree[nodeIndex].timeout = time.Now().UTC()
+	h.Tree[nodeIndex].Timeout = time.Now().UTC()
 
 	if nodeIndex+1 < h.currentSize {
 		if h.compareTwoTimes(nodeIndex, nodeIndex+1) {
@@ -183,7 +183,7 @@ func (h *Heap) percolateUp(newNodeIndex int) {
 	preExistingNode := h.Tree[newNodeIndex-1]
 
 	// Unlikely to ever do anything.
-	if newlyInsertedNode.timeout.Nanosecond() < preExistingNode.timeout.Nanosecond() {
+	if newlyInsertedNode.Timeout.Nanosecond() < preExistingNode.Timeout.Nanosecond() {
 		h.swapTwoNodes(newNodeIndex, newNodeIndex-1)
 		h.percolateUp(newNodeIndex - 1)
 	}
@@ -215,7 +215,7 @@ func (h *Heap) percolateDown(fromIndex int) {
 	}
 
 	// Unlikely to ever do anything. But it asserts that the minimum
-	if trackerNode.timeout.Nanosecond() > preExistingNode.timeout.Nanosecond() {
+	if trackerNode.Timeout.Nanosecond() > preExistingNode.Timeout.Nanosecond() {
 		h.swapTwoNodes(fromIndex, fromIndex+1)
 		h.percolateDown(fromIndex + 1)
 	}
@@ -223,7 +223,7 @@ func (h *Heap) percolateDown(fromIndex int) {
 
 // swapTwoNodes swaps j into i and vice versa. Moreover, it handles updating
 // the keyLookup field in the heap so that we can continue to quickly retrieve
-// key timeouts.
+// key Timeouts.
 func (h *Heap) swapTwoNodes(i int, j int) {
 	// If we find a value at Tree[i], we can update it in the keylookup,
 	// otherwise disregard, as it's a recently evicted node.
@@ -242,7 +242,7 @@ func (h *Heap) swapTwoNodes(i int, j int) {
 // (j), then we return True. Otherwise, if the left (i) has an expiration time
 // _before_ the right (j) we return a False.
 func (h *Heap) compareTwoTimes(i int, j int) bool {
-	if h.Tree[i].timeout.Nanosecond() > h.Tree[j].timeout.Nanosecond() {
+	if h.Tree[i].Timeout.Nanosecond() > h.Tree[j].Timeout.Nanosecond() {
 		return true
 	} else {
 		return false

--- a/shared/binary_heap_test.go
+++ b/shared/binary_heap_test.go
@@ -1,4 +1,4 @@
-package olilib_lru
+package shared
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 func TestNewNode(t *testing.T) {
 	expectedReturn := Node{
 		Key:     "TestingNewNodeKey",
-		timeout: time.Now().UTC(),
+		Timeout: time.Now().UTC(),
 	}
 
 	time.Sleep(5 * time.Millisecond)
@@ -20,10 +20,10 @@ func TestNewNode(t *testing.T) {
 		t.Errorf("Expected %v, got %v", expectedReturn.Key, retVal.Key)
 	}
 
-	if expectedReturn.timeout.Nanosecond() >= retVal.timeout.Nanosecond() {
+	if expectedReturn.Timeout.Nanosecond() >= retVal.Timeout.Nanosecond() {
 		t.Errorf("Expected expectedReturn (%v) to be lower than retval (%v)",
-			expectedReturn.timeout,
-			retVal.timeout,
+			expectedReturn.Timeout,
+			retVal.Timeout,
 		)
 	}
 }
@@ -327,7 +327,7 @@ func TestKeyUpdateTimeoutDoesntBlowUpEverything(t *testing.T) {
 	for i := 0; i < len(testHeap.Tree)-1; i++ {
 		for j := i + 1; j < len(testHeap.Tree)-1; j++ {
 			if testHeap.compareTwoTimes(i, j) {
-				t.Errorf("%v - %v", testHeap.Tree[i].Key, testHeap.Tree[i].timeout)
+				t.Errorf("%v - %v", testHeap.Tree[i].Key, testHeap.Tree[i].Timeout)
 				break
 			}
 		}


### PR DESCRIPTION
CHANGE:
- The binary heap now lives in the shared/ folder instead of the LRU
  cache folder, as the binary heap needs to be implemented as part of
  the key expiration.
