### PR TITLE
Fixes #83

### DIFF
--- a/bloomfilter/bloom.go
+++ b/bloomfilter/bloom.go
@@ -2,7 +2,6 @@ package olilib
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/GrappigPanda/Olivia/lru_cache"
 	"hash/fnv"
 	"math"
@@ -70,7 +69,11 @@ func (bf *BloomFilter) ConvertToString() string {
 	var buffer bytes.Buffer
 
 	for i := range bf.Filter {
-		buffer.WriteString(fmt.Sprintf("%v", bf.Filter[i]))
+		if bf.Filter[i] != 0 {
+			buffer.WriteString("I")
+		} else {
+			buffer.WriteString("O")
+		}
 	}
 
 	return Encode(buffer.String())
@@ -86,7 +89,14 @@ func ConvertStringtoBF(inputString string) (*BloomFilter, error) {
 
 	index := 0
 	for i, _ := range decodedString {
-		number, err := strconv.Atoi(string(decodedString[i]))
+		var char string
+		if decodedString[i] == 'O' {
+			char = "0"
+		} else {
+			char = "1"
+		}
+
+		number, err := strconv.Atoi(char)
 		if err != nil {
 			return nil, err
 		}

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -1,9 +1,9 @@
 package olilib
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
-	"fmt"
 )
 
 // Encode handles encoding the bloom filter.
@@ -55,7 +55,6 @@ func Encode(inputString string) string {
 		count,
 	)
 
-
 	return output
 }
 
@@ -67,29 +66,21 @@ func Decode(encodedString string) string {
 	}
 
 	var output string
-	var increment bool
+	var accumulatedInt string
+	var trackedChar byte
 
-	var i int = 0
-	encodedStringLength := len(encodedString) - 1
-	for i = 0; i <= encodedStringLength; {
-		if i + 1 <= encodedStringLength {
-			repeatCount, err := strconv.Atoi(string(encodedString[i + 1]))
-			if err != nil {
-				repeatCount = 1
-				increment = true
+	for i := 0; i < len(encodedString); i++ {
+		if _, err := strconv.Atoi(string(encodedString[i])); err == nil {
+			accumulatedInt = fmt.Sprintf("%v%v", accumulatedInt, encodedString[i])
+		} else {
+			if accumulatedInt != "" {
+				count, _ := strconv.Atoi(accumulatedInt)
+				output = writeRepeat(output, trackedChar, count)
+				trackedChar = encodedString[i]
+			} else {
+				trackedChar = encodedString[i]
 			}
-			output = writeRepeat(output, encodedString[i], repeatCount)
-		} else {
-			output = writeRepeat(output, encodedString[i], 1)
 		}
-
-		if increment || i + 2 > encodedStringLength + 1 {
-			i++
-		} else {
-			i += 2
-		}
-
-		increment = false
 	}
 
 	return output
@@ -106,22 +97,6 @@ func writeOutput(outputString string, char byte, count int) string {
 			outputString,
 			string(char),
 		)
-	} else if count > 9 {
-		number := "9"
-		retVal = outputString
-		for x := 0; x <= count / 9; x++ {
-			if x == count / 9  && count % 9 != 0{
-				number = strconv.Itoa(count % 9)
-			} else if x == count / 9 {
-				continue
-			}
-			retVal = fmt.Sprintf(
-				"%s%s%s",
-				retVal,
-				string(char),
-				number,
-			)
-		}
 	} else {
 		retVal = fmt.Sprintf(
 			"%s%s%d",
@@ -130,7 +105,6 @@ func writeOutput(outputString string, char byte, count int) string {
 			count,
 		)
 	}
-
 
 	return retVal
 }

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -63,32 +63,38 @@ func Encode(inputString string) string {
 func Decode(encodedString string) string {
 	if len(encodedString) == 0 {
 		return ""
-	} else if len(encodedString)%2 != 0 {
-		return ""
 	}
 
 	var output string
 	var accumulatedInt string
 	var trackedChar byte
 
-	for i := 0; i < len(encodedString); i++ {
+	for i := 0; i <= len(encodedString); i++ {
+		if i == len(encodedString) {
+			count, _ := strconv.Atoi(accumulatedInt)
+			output = writeRepeat(output, trackedChar, count)
+
+			continue
+		}
+
 		if _, err := strconv.Atoi(string(encodedString[i])); err == nil {
-			accumulatedInt = fmt.Sprintf("%v%v", accumulatedInt, encodedString[i])
+			if accumulatedInt == "0" {
+				accumulatedInt = string(encodedString[i])
+			} else {
+				accumulatedInt = fmt.Sprintf("%s%s", accumulatedInt, string(encodedString[i]))
+			}
+
 		} else {
 			if accumulatedInt != "" {
-				count, err := strconv.Atoi(accumulatedInt)
-				if err != nil {
-					// If we hit an error here, tehre is something really
-					// messed up with the input.
-					panic("Invalid characters detected in RLE")
-				}
+				count, _ := strconv.Atoi(accumulatedInt)
 
 				output = writeRepeat(output, trackedChar, count)
-				trackedChar = encodedString[i]
-				accumulatedInt = ""
-			} else {
-				trackedChar = encodedString[i]
+			} else if accumulatedInt == "0" {
+				output = writeRepeat(output, trackedChar, 1)
 			}
+
+			trackedChar = encodedString[i]
+			accumulatedInt = "0"
 		}
 	}
 

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -85,6 +85,7 @@ func Decode(encodedString string) string {
 
 				output = writeRepeat(output, trackedChar, count)
 				trackedChar = encodedString[i]
+				accumulatedInt = ""
 			} else {
 				trackedChar = encodedString[i]
 			}

--- a/bloomfilter/rle.go
+++ b/bloomfilter/rle.go
@@ -63,6 +63,8 @@ func Encode(inputString string) string {
 func Decode(encodedString string) string {
 	if len(encodedString) == 0 {
 		return ""
+	} else if len(encodedString)%2 != 0 {
+		return ""
 	}
 
 	var output string
@@ -74,7 +76,13 @@ func Decode(encodedString string) string {
 			accumulatedInt = fmt.Sprintf("%v%v", accumulatedInt, encodedString[i])
 		} else {
 			if accumulatedInt != "" {
-				count, _ := strconv.Atoi(accumulatedInt)
+				count, err := strconv.Atoi(accumulatedInt)
+				if err != nil {
+					// If we hit an error here, tehre is something really
+					// messed up with the input.
+					panic("Invalid characters detected in RLE")
+				}
+
 				output = writeRepeat(output, trackedChar, count)
 				trackedChar = encodedString[i]
 			} else {
@@ -112,6 +120,7 @@ func writeOutput(outputString string, char byte, count int) string {
 // writeRepeat handles writing repeating characters intelligently
 func writeRepeat(output string, char byte, repeat int) string {
 	var retVal string
+	fmt.Println(repeat)
 
 	// If the next character is an integer, we can encode it.
 	if repeat > 1 {

--- a/bloomfilter/rle_test.go
+++ b/bloomfilter/rle_test.go
@@ -13,15 +13,6 @@ func TestEncode(t *testing.T) {
 	}
 }
 
-func TestEncodeIntegers(t *testing.T) {
-	expectedReturn := "052234"
-	retVal := Encode("00000223333")
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
 func TestDecode(t *testing.T) {
 	expectedReturn := "AAABZZZZZTTT"
 	retVal := Decode("A3BZ5T3")
@@ -31,8 +22,17 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestDecodeLongString(t *testing.T) {
+	expectedReturn := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	retVal := Decode("a30")
+
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+}
+
 func TestWriteOutputOver9(t *testing.T) {
-	expectedReturn := "a9a9a9a9a9a9a9"
+	expectedReturn := "a63"
 	retVal := writeOutput("", 'a', 63)
 
 	if expectedReturn != retVal {
@@ -41,18 +41,8 @@ func TestWriteOutputOver9(t *testing.T) {
 }
 
 func TestWriteOutputOver9WithExtra(t *testing.T) {
-	expectedReturn := "a9a9a9a9a9a9a9a5"
+	expectedReturn := "a68"
 	retVal := writeOutput("", 'a', 68)
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
-
-func TestDencodeIntegers(t *testing.T) {
-	expectedReturn := "00000223333"
-	retVal := Decode("052234")
 
 	if expectedReturn != retVal {
 		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
@@ -67,45 +57,4 @@ func TestEncodeDecode(t *testing.T) {
 	if expectedReturn != retVal {
 		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
 	}
-}
-
-func TestEncodeDecodeIntegers(t *testing.T) {
-	expectedReturn := "00000223333"
-	retVal := Encode(expectedReturn)
-	retVal = Decode(retVal)
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
-func TestEncodeLongString(t *testing.T) {
-	expectedReturn := "09150909090335524"
-	retVal := Encode("0000000001111100000000000000000000000000000033333554")
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
-func TestDecodeLongString(t *testing.T) {
-	expectedReturn := "0000000001111100000000000000000000000000000033333554"
-	retVal := Decode("09150909090335524")
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
-func TestDecodeLongStringLongStringAtEnd(t *testing.T) {
-	expectedReturn := "000000000111110000000000000000000000000000004444444"
-	retVal := Decode("09150909090347")
-
-	if expectedReturn != retVal {
-		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
-	}
-}
-
-func TestEncodeDecodeLongString(t *testing.T) {
-
 }


### PR DESCRIPTION
CHANGE:
- bloom.go Now encodes 0s => "O" and 1s => "1" to temporarily increase RLE
  performance.
- rle.go: halfway through completing change to better encoding.
