### PR TITLE
Fixes #115

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/spf13/viper"
+	"log"
 )
 
 // Config houses information loaded from the config file.
@@ -25,7 +26,8 @@ func ReadConfig() *Cfg {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(err)
+		// If we get an error here, we just fallback to the defaults.
+		log.Println("No config file found! Falling back to defaults.")
 	}
 
 	return &Cfg{

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -89,8 +89,6 @@ func (ctx *ConnectionCtx) handleConnection(conn *net.Conn) {
 	(*ctx.PeerList).AddPeer((*conn).RemoteAddr().String())
 
 	for {
-		// TODO(ian): Replace this with a new language processor for incoming
-		// commands
 		password := "TestBcryptPassword"
 		line, _, err := reader.ReadLine()
 		if err != nil {
@@ -101,6 +99,10 @@ func (ctx *ConnectionCtx) handleConnection(conn *net.Conn) {
 		switch connProc.State {
 		case UNAUTHENTICATED:
 			connProc.Authenticate(password)
+			log.Println(
+				"Unauthenticated request from %v",
+				(*conn).RemoteAddr().String(),
+			)
 			break
 		case PROCESSING:
 			command, err := ctx.Parser.Parse(string(line), conn)

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -29,38 +29,52 @@ func StartNetworkRouter(
 	cache *cache.Cache,
 	peerList *dht.PeerList,
 	config *config.Cfg,
-) {
+) chan struct{} {
+	stopchan := make(chan struct{})
 
-	listen, err := net.Listen("tcp", ":5454")
-	if err != nil {
-		panic(err)
-	}
-	defer listen.Close()
-
-	bf := olilib.NewByFailRate(1000, 0.01)
-
-	ctx := &ConnectionCtx{
-		parser.NewParser(mh),
-		cache,
-		bf,
-		mh,
-		peerList,
-	}
-
-	log.Println("Starting connection router.")
-
-	for {
-		conn, err := listen.Accept()
+	// Here we spin up a network router which allows us to start/stop on demand
+	// via channels. It's overly indented, this should probably be seperated
+	// elsewhere.
+	go func(stopchan chan struct{}) {
+		listen, err := net.Listen("tcp", ":5454")
 		if err != nil {
-			log.Println(err)
-			continue
+			panic(err)
 		}
-		log.Println("Incoming connection detected from ",
-			conn.RemoteAddr().String(),
-		)
+		defer listen.Close()
 
-		go ctx.handleConnection(&conn)
-	}
+		bf := olilib.NewByFailRate(1000, 0.01)
+
+		ctx := &ConnectionCtx{
+			parser.NewParser(mh),
+			cache,
+			bf,
+			mh,
+			peerList,
+		}
+
+		log.Println("Starting connection router.")
+
+		for {
+			select {
+			default:
+				conn, err := listen.Accept()
+				if err != nil {
+					log.Println(err)
+					continue
+				}
+				log.Println("Incoming connection detected from ",
+					conn.RemoteAddr().String(),
+				)
+
+				go ctx.handleConnection(&conn)
+			case <-stopchan:
+				log.Printf("Forcefully quitting network router.")
+				return
+			}
+		}
+	}(stopchan)
+
+	return stopchan
 }
 
 // handleConnection handles handling state of the incoming network FSM,

--- a/network/incoming/incoming_network_test.go
+++ b/network/incoming/incoming_network_test.go
@@ -1,0 +1,39 @@
+package incomingNetwork
+
+import (
+	"github.com/GrappigPanda/Olivia/cache"
+	"github.com/GrappigPanda/Olivia/config"
+	"github.com/GrappigPanda/Olivia/dht"
+	"github.com/GrappigPanda/Olivia/network/message_handler"
+	"os"
+	"testing"
+)
+
+func TestStartStopNetworkRouter(t *testing.T) {
+	t.Errorf("test")
+}
+
+func TestGetBloomfilter(t *testing.T) {
+
+}
+
+func TestSetKey(t *testing.T) {
+
+}
+
+func TestGetKeyFromRemoteNode(t *testing.T) {
+	// It's not yet possible to do this, for this to be done, we need to first
+	// add listening ports and base nodes to be a part of the config file.
+}
+
+func TestMain(m *testing.M) {
+	mh := message_handler.NewMessageHandler()
+	cache := cache.NewCache()
+	peerList := dht.NewPeerList(mh)
+	config := config.ReadConfig()
+	stopchan := StartNetworkRouter(mh, cache, peerList, config)
+
+	os.Exit(m.Run())
+
+	stopchan <- struct{}{}
+}

--- a/network/incoming/incoming_network_test.go
+++ b/network/incoming/incoming_network_test.go
@@ -1,24 +1,94 @@
 package incomingNetwork
 
 import (
+	"bufio"
+	"fmt"
+	"github.com/GrappigPanda/Olivia/bloomfilter"
 	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/config"
 	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/network/message_handler"
+	"net"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
-func TestStartStopNetworkRouter(t *testing.T) {
-	t.Errorf("test")
+var BASENODE = "127.0.0.1:5454"
+
+func sendCommand(command string, t *testing.T) string {
+	conn, err := net.DialTimeout("tcp", BASENODE, 1*time.Second)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	conn.Write([]byte(fmt.Sprintf("%s\n", command)))
+
+	reader := bufio.NewReader(conn)
+	str, err := reader.ReadString('\n')
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	return str
 }
 
 func TestGetBloomfilter(t *testing.T) {
+	// All this test needs to do is assure us that we get a properly formatted
+	// bloom filter in the return. We don't need to worry about if it matches
+	// anything, as we have tests for that already.
+	str := sendCommand("REQUEST bloomfilter\n", t)
 
+	bf_str := strings.Split(str, " ")
+	inputStr := strings.TrimSpace(bf_str[1])
+	_, err := olilib.ConvertStringtoBF(inputStr)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+func TestPingPong(t *testing.T) {
+	pong := sendCommand("PING 0", t)
+	if pong != "0:PONG 1\n" {
+		t.Errorf("Expected 0:PONG 1, got %v", pong)
+	}
 }
 
 func TestSetKey(t *testing.T) {
+	expectedReturn := ":SAT key1:value1\n"
+	retVal := sendCommand("SET key1:value1\n", t)
 
+	if expectedReturn != retVal {
+		t.Errorf("Expected %v, got %v", expectedReturn, retVal)
+	}
+
+	// I intentionally don't test sending in multiple keys here, as I test it
+	// in the bloom filter update below.
+}
+
+func TestSetKeyUpdatesBloomFilter(t *testing.T) {
+	sendCommand("SET key1:value1,key2:value2,key3:value\n", t)
+
+	str := sendCommand("REQUEST bloomfilter\n", t)
+
+	bf_str := strings.Split(str, " ")
+	inputStr := strings.TrimSpace(bf_str[1])
+	bf, err := olilib.ConvertStringtoBF(inputStr)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if ok, _ := bf.HasKey([]byte("key1")); !ok {
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+	}
+
+	if ok, _ := bf.HasKey([]byte("key2")); !ok {
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+	}
+
+	if ok, _ := bf.HasKey([]byte("key3")); !ok {
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+	}
 }
 
 func TestGetKeyFromRemoteNode(t *testing.T) {


### PR DESCRIPTION
ADD:
- incoming_network_test.go Now has tests to verify that the common operations
  work on a single node (I.e., no DHT lookups.)
- The network router can now be stopped via a channel and we're beginning to
  add unit tests to test it out.
