### PR TITLE
Fixes #113

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,19 @@
+# Size of bloom filters. 
+# Default: 1000 
 BFSize: 1000
+# BaseNode signifies that, upon start, the node will not attempt to connect to
+# any other remote nodes. Essentially one node will be spun up and then others
+# may attempt to connect to this base node. The default is set to True if the
+# config file doesn to load correctly.
+# Default: true
+BaseNode: true
+# Rate at which we send pings to important remote nodes. 
+# Default: 1000 (in milliseconds)
+HeartbeatInterval: 1000
+# Default rate at which we send pings to any other nodes. 
+# Default: 30 (in seconds)
+HeartbeatCycle: 30
+# A list of nodes which our node will attempt to connect to upon startup.
+# Default: 127.0.0.1:5455
+RemotePeers:
+  - 127.0.0.1:5455    

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,8 @@ type Cfg struct {
 	HeartbeatInterval int
 	HeartbeatLoop     int
 	BloomfilterSize   int
+	BaseNode          bool
+	RemotePeers       []string
 }
 
 // ReadConfig handles opening a file and creating a config object for use
@@ -21,8 +23,11 @@ func ReadConfig() *Cfg {
 	viper.AddConfigPath(".")
 
 	viper.SetDefault("bfsize", 1000)
-	viper.SetDefault("Heartbeatloop", 30)
-	viper.SetDefault("Heartbeatinterval", 1000)
+	viper.SetDefault("heartbeatloop", 30)
+	viper.SetDefault("heartbeatinterval", 1000)
+	viper.SetDefault("basenode", true)
+	// By default we assume no peers because
+	viper.SetDefault("remotepeers", []string{})
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -34,5 +39,7 @@ func ReadConfig() *Cfg {
 		viper.Get("heartbeatinterval").(int),
 		viper.Get("heartbeatloop").(int),
 		viper.Get("bfsize").(int),
+		viper.GetBool("basenode"),
+		viper.GetStringSlice("remotepeers"),
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,5 +5,31 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	_ = ReadConfig()
+	cfg := ReadConfig()
+
+	// Please note: If this is failing, it's probably due to the fact that the
+	// config file was edited.
+	if cfg.BaseNode != true {
+		t.Errorf("Expected true, got %v", cfg.BaseNode)
+	}
+
+	if cfg.BloomfilterSize != 1000 {
+		t.Errorf("Expected 1000, got %v", cfg.BloomfilterSize)
+	}
+
+	if cfg.HeartbeatInterval != 1000 {
+		t.Errorf("Expected 1000, got %v", cfg.HeartbeatInterval)
+	}
+
+	if cfg.HeartbeatLoop != 30 {
+		t.Errorf("Expected 30, got %v", cfg.HeartbeatLoop)
+	}
+
+	for _, peer := range cfg.RemotePeers {
+		if peer != "127.0.0.1:5455" {
+			t.Errorf("Expected 127.0.0.1:5455, got %v", peer)
+		} else {
+			break
+		}
+	}
 }

--- a/network/network_handler.go
+++ b/network/network_handler.go
@@ -95,23 +95,35 @@ func StartIncomingNetwork(
 	config *config.Cfg,
 ) {
 	peerList := dht.NewPeerList(mh)
-	peer := dht.NewPeerByIP("127.0.0.1:5454", mh)
-	peerList.Peers[0] = peer
-	(*peerList.PeerMap)["127.0.0.1:5454"] = true
 
-	err := peerList.ConnectAllPeers()
-	if err != nil {
-		for err != nil {
-			log.Println("Sleeping for 60 seconds and attempting to reconnect")
-			time.Sleep(time.Second * 60)
-			err = peerList.ConnectAllPeers()
+	// BaseNode==True signifies that we're not expecting to connect to any
+	// remote nodes on connection, so if it's false, we'll skip that step and
+	// just wait for incoming connections.
+	if !config.BaseNode {
+		for index, peerIP := range config.RemotePeers {
+			peer := dht.NewPeerByIP(peerIP, mh)
+			peerList.Peers[index] = peer
+			(*peerList.PeerMap)[peerIP] = true
 		}
+
+		err := peerList.ConnectAllPeers()
+		if err != nil {
+			for err != nil {
+				log.Println("Sleeping for 60 seconds and attempting to reconnect")
+				time.Sleep(time.Second * 60)
+				err = peerList.ConnectAllPeers()
+			}
+		}
+
+		Heartbeat(
+			1000*time.Millisecond,
+			1*time.Second,
+			peerList,
+		)
 	}
 
-	Heartbeat(
-		1000*time.Millisecond,
-		1*time.Second,
-		peerList,
-	)
 	incomingNetwork.StartNetworkRouter(mh, cache, peerList, config)
+	// TODO(ian): Clean up this for statement, it's technical debt.
+	for {
+	}
 }


### PR DESCRIPTION
ADD:
- config.go:Cfg `BaseNode` and `RemotePeers` were added as config variables
  which can be used to instruct the network router how to start (do we start
  by connecting to remote peers, or assume we're the only peer and just be
  ready for incoming connections).
- config_test.go Now actually verifies we're getting data and loading it
  properly.
- network_handler.go:StartNetworkRouter Is now aware of base nodes and remote
  peers in the config, so it will attempt to connect to remote peer IFF it is
  not a base node.
