### PR TITLE
Fixes #112

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,9 @@ HeartbeatInterval: 1000
 # Default rate at which we send pings to any other nodes. 
 # Default: 30 (in seconds)
 HeartbeatCycle: 30
+# Port we listen for incoming connections on.
+# Default: 5454
+ListenPort: 5454
 # A list of nodes which our node will attempt to connect to upon startup.
 # Default: 127.0.0.1:5455
 RemotePeers:

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Cfg struct {
 	BloomfilterSize   int
 	BaseNode          bool
 	RemotePeers       []string
+	ListenPort        int
 }
 
 // ReadConfig handles opening a file and creating a config object for use
@@ -26,8 +27,9 @@ func ReadConfig() *Cfg {
 	viper.SetDefault("heartbeatloop", 30)
 	viper.SetDefault("heartbeatinterval", 1000)
 	viper.SetDefault("basenode", true)
-	// By default we assume no peers because
+	// By default we assume no peers because we assume we're a base node.
 	viper.SetDefault("remotepeers", []string{})
+	viper.SetDefault("listenport", 5454)
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -41,5 +43,6 @@ func ReadConfig() *Cfg {
 		viper.Get("bfsize").(int),
 		viper.GetBool("basenode"),
 		viper.GetStringSlice("remotepeers"),
+		viper.GetInt("listenport"),
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,4 +32,9 @@ func TestConfig(t *testing.T) {
 			break
 		}
 	}
+
+	if cfg.ListenPort != 5454 {
+		t.Errorf("Expected 5454, got %v", cfg.HeartbeatLoop)
+	}
+
 }

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -2,6 +2,7 @@ package incomingNetwork
 
 import (
 	"bufio"
+	"fmt"
 	"github.com/GrappigPanda/Olivia/bloomfilter"
 	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/config"
@@ -36,7 +37,7 @@ func StartNetworkRouter(
 	// via channels. It's overly indented, this should probably be seperated
 	// elsewhere.
 	go func(stopchan chan struct{}) {
-		listen, err := net.Listen("tcp", ":5454")
+		listen, err := net.Listen("tcp", fmt.Sprintf(":%d", config.ListenPort))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
ADD:
- config.yaml: Added a new `ListenPort` default to 5454 where the incoming
  network will listen on.
- config.go:Cfg added a ListenPort option for the config.

CHANGE:
- incoming_network.go:StartNetwork() Now loads the listen port for incoming
  connections from the config, rather than using a magic number.
