### PR TITLE
Fixes #130

### DIFF
--- a/dht/peer.go
+++ b/dht/peer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GrappigPanda/Olivia/parser"
 	"log"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -35,6 +36,7 @@ type Peer struct {
 	BloomFilter  *olilib.BloomFilter
 	MessageBus   *message_handler.MessageHandler
 	failureCount int
+	sync.Mutex
 }
 
 // NewPeer handles creating a new peer to be used in communicating between nodes
@@ -43,24 +45,24 @@ func NewPeer(conn *net.Conn, mh *message_handler.MessageHandler) *Peer {
 	log.Println("New peer connected: %v", ipPort)
 
 	return &Peer{
-		Disconnected,
-		conn,
-		ipPort,
-		nil,
-		mh,
-		0,
+		Status:       Disconnected,
+		Conn:         conn,
+		IPPort:       ipPort,
+		BloomFilter:  nil,
+		MessageBus:   mh,
+		failureCount: 0,
 	}
 }
 
 // NewPeerByIP handles creating a peer by its ip, opening a connection, &c.
 func NewPeerByIP(ipPort string, mh *message_handler.MessageHandler) *Peer {
 	newPeer := &Peer{
-		Disconnected,
-		nil,
-		ipPort,
-		nil,
-		mh,
-		0,
+		Status:       Disconnected,
+		Conn:         nil,
+		IPPort:       ipPort,
+		BloomFilter:  nil,
+		MessageBus:   mh,
+		failureCount: 0,
 	}
 
 	return newPeer
@@ -147,6 +149,8 @@ func (p *Peer) GetBloomFilter() {
 
 		for k, _ := range responseData.Args {
 			bf, err := olilib.ConvertStringtoBF(k)
+			p.Lock()
+			defer p.Unlock()
 			if err != nil {
 				p.BloomFilter = nil
 			}

--- a/dht/peer.go
+++ b/dht/peer.go
@@ -146,7 +146,7 @@ func (p *Peer) GetBloomFilter() {
 		}
 
 		for k, _ := range responseData.Args {
-			bf, err := olilib.ConvertStringtoBF(responseData.Args[k])
+			bf, err := olilib.ConvertStringtoBF(k)
 			if err != nil {
 				p.BloomFilter = nil
 			}

--- a/dht/peer.go
+++ b/dht/peer.go
@@ -78,6 +78,7 @@ func (p *Peer) Connect() error {
 
 	p.Conn = &conn
 	p.Status = Connected
+	p.GetBloomFilter()
 
 	return nil
 }

--- a/dht/peerlist.go
+++ b/dht/peerlist.go
@@ -100,6 +100,7 @@ func (p *PeerList) ConnectAllPeers() error {
 		log.Println("Sending Request Connect")
 		p.Peers[x].SendCommand("0:REQUEST CONNECT\n")
 		p.Peers[x].GetPeerList(responseChannel)
+		p.Peers[x].GetBloomFilter()
 	}
 
 	if failureCount == len(p.Peers) {

--- a/network/network_handler.go
+++ b/network/network_handler.go
@@ -82,6 +82,8 @@ func Heartbeat(
 ) {
 	go heartbeatRemoteNodes(peerList.Peers, heartbeatInterval)
 	go heartbeatRemoteNodes(peerList.BackupPeers, cycleDuration)
+	go getRemoteBloomFilters(peerList.Peers, cycleDuration)
+	go getRemoteBloomFilters(peerList.BackupPeers, cycleDuration)
 }
 
 // StartIncomingNetwork handles spinning up an incoming network router and
@@ -115,8 +117,8 @@ func StartIncomingNetwork(
 		}
 
 		Heartbeat(
-			1000*time.Millisecond,
-			1*time.Second,
+			time.Duration(config.HeartbeatInterval)*time.Millisecond,
+			time.Duration(config.HeartbeatLoop)*time.Second,
 			peerList,
 		)
 	}


### PR DESCRIPTION
ADD:
- dht/peerlist.go:ConnectAllNodes() Now calls Peer:GetBloomFilter() per node.
- dht/peer.go:GetBloomFilter() Now parses the bloom filter correctly.
  Previously it was indexing the requestData.Args[k] instead of just using
  `k`.
