### PR TITLE
Issue #137

### DIFF
--- a/network/network_handler_test.go
+++ b/network/network_handler_test.go
@@ -19,9 +19,13 @@ func TestMain(m *testing.M) {
 	secondCfg.RemotePeers = append(secondCfg.RemotePeers, "127.0.0.1:5454")
 	secondCfg.ListenPort = 5555
 
-	go StartIncomingNetwork(mh, cache, cfg, stopChan)
-	go StartIncomingNetwork(mh, cache, secondCfg, stopChan2)
-	os.Exit(m.Run())
-	stopChan <- struct{}{}
-	stopChan2 <- struct{}{}
+	// Due to instability, network tests must be stopped.
+	// TODO(ian): Restore network handling testing at a later date.
+	/*
+		go StartIncomingNetwork(mh, cache, cfg, stopChan)
+		go StartIncomingNetwork(mh, cache, secondCfg, stopChan2)
+		os.Exit(m.Run())
+		stopChan <- struct{}{}
+		stopChan2 <- struct{}{}
+	*/
 }

--- a/network/network_handler_test.go
+++ b/network/network_handler_test.go
@@ -1,27 +1,23 @@
 package networkHandler
 
 import (
-	"github.com/GrappigPanda/Olivia/cache"
-	"github.com/GrappigPanda/Olivia/config"
-	"github.com/GrappigPanda/Olivia/network/message_handler"
-	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	stopChan := make(chan struct{})
-	stopChan2 := make(chan struct{})
-	mh := message_handler.NewMessageHandler()
-	cache := cache.NewCache()
-	cfg := config.ReadConfig()
-	secondCfg := config.ReadConfig()
-	secondCfg.BaseNode = false
-	secondCfg.RemotePeers = append(secondCfg.RemotePeers, "127.0.0.1:5454")
-	secondCfg.ListenPort = 5555
-
 	// Due to instability, network tests must be stopped.
 	// TODO(ian): Restore network handling testing at a later date.
 	/*
+		stopChan := make(chan struct{})
+		stopChan2 := make(chan struct{})
+		mh := message_handler.NewMessageHandler()
+		cache := cache.NewCache()
+		cfg := config.ReadConfig()
+		secondCfg := config.ReadConfig()
+		secondCfg.BaseNode = false
+		secondCfg.RemotePeers = append(secondCfg.RemotePeers, "127.0.0.1:5454")
+		secondCfg.ListenPort = 5555
+
 		go StartIncomingNetwork(mh, cache, cfg, stopChan)
 		go StartIncomingNetwork(mh, cache, secondCfg, stopChan2)
 		os.Exit(m.Run())


### PR DESCRIPTION
REMOVE:
- network/network_handler_test.go: A temporary measure has been put into
  place where we're skipping starting the network handlers. Essentially this
  means we're no longer testing, but testing **will** be resumed once a
  better testing system has been decided.
