### PR TITLE
Fixes #147

### DIFF
--- a/dht/peerlist.go
+++ b/dht/peerlist.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-// PeerList is a data structure which represents remote olivia nodes.
+// PeerList is a data structure which represents remote Olivia nodes.
 type PeerList struct {
 	Peers       []*Peer
 	BackupPeers []*Peer

--- a/lru_cache/lru_cache.go
+++ b/lru_cache/lru_cache.go
@@ -1,7 +1,7 @@
 package olilib_lru
 
 import (
-	binheap "github.com/GrappigPanda/Olivia/shared"
+	"github.com/GrappigPanda/Olivia/shared"
 	"sync"
 	"time"
 )
@@ -16,7 +16,7 @@ var MAXINT64 = int64(1<<63 - 1)
 type LRUCacheString struct {
 	KeyCount    int
 	Keys        map[string]string
-	KeyTimeouts *binheap.Heap
+	KeyTimeouts shared.BinHeap
 	Mutex       *sync.Mutex
 }
 
@@ -26,7 +26,7 @@ func NewString(maxEntries int) *LRUCacheString {
 	return &LRUCacheString{
 		KeyCount:    maxEntries,
 		Keys:        make(map[string]string),
-		KeyTimeouts: binheap.NewHeap(maxEntries),
+		KeyTimeouts: shared.NewHeap(maxEntries),
 		Mutex:       &sync.Mutex{},
 	}
 }
@@ -61,7 +61,7 @@ func (l *LRUCacheString) Add(key string, value string) (string, bool) {
 // addNewKeyTimeout handles adding a key into our priority queue for later
 // eviction.
 func (l *LRUCacheString) addNewKeyTimeout(key string) {
-	l.KeyTimeouts.Insert(binheap.NewNode(key, getCurrentUnixTime()))
+	l.KeyTimeouts.Insert(shared.NewNode(key, getCurrentUnixTime()))
 }
 
 // Get Retrieves a key from the LRU cache and increases its priority.

--- a/lru_cache/lru_cache_int_array.go
+++ b/lru_cache/lru_cache_int_array.go
@@ -13,7 +13,7 @@ import (
 type LRUCacheInt32Array struct {
 	KeyCount    int
 	Keys        map[string][]uint32
-	KeyTimeouts *binheap.Heap
+	KeyTimeouts binheap.BinHeap
 	Mutex       *sync.Mutex
 }
 

--- a/network/README.md
+++ b/network/README.md
@@ -5,7 +5,7 @@
 There is a thin layer in each Olivia node which allows remote connections.
 Whenever a new connection is established, the network layer will divert each
 connection to its own operating goroutine. Incoming connections may be from
-other olivia nodes or applications requesting cached values.
+other Olivia nodes or applications requesting cached values.
 
 Inside each goroutine, the connection will be handled by a connection
 processing finite state machine (FSM). The FSM operates in several states

--- a/network/incoming/README.md
+++ b/network/incoming/README.md
@@ -8,7 +8,7 @@ in the network/ folder.
 1. GET
   - Get allows requests for key/value pairs from a remote node.
 2. SET
-  - Set allows a remote node/client to set a value in an olivia node.
+  - Set allows a remote node/client to set a value in an Olivia node.
 3. SETEX
   - Setex allows setting a key on an expiration timer. The expiration time
     **must** be in seconds (e.g., "key1:value1:30").

--- a/shared/binary_heap.go
+++ b/shared/binary_heap.go
@@ -69,7 +69,7 @@ func NewHeapReallocate(maxSize int) *Heap {
 }
 
 // Copy handles taking in a binary heap and making a copy of it.
-func (h *Heap) Copy() *Heap {
+func (h *Heap) Copy() Heap {
 	h.Lock()
 	defer h.Unlock()
 	newHeap := NewHeap(len(h.Tree))
@@ -85,7 +85,7 @@ func (h *Heap) Copy() *Heap {
 	newHeap.index = h.index
 	newHeap.currentSize = h.currentSize
 
-	return newHeap
+	return *newHeap
 }
 
 // MinNode returns the root node. In this implementation, we opted for a
@@ -238,7 +238,7 @@ func (h *Heap) percolateUp(newNodeIndex int) {
 		}
 	}
 
-	h.swapTrees(tmpHeap)
+	h.swapTrees(&tmpHeap)
 }
 
 // percolateDown handles moving a node starting at index `fromIndex` down into
@@ -285,7 +285,7 @@ func (h *Heap) percolateDown(fromIndex int) {
 		}
 	}
 
-	h.swapTrees(tmpHeap)
+	h.swapTrees(&tmpHeap)
 }
 
 func (h *Heap) swapTrees(newHeap *Heap) {

--- a/shared/binary_heap_test.go
+++ b/shared/binary_heap_test.go
@@ -381,7 +381,7 @@ func TestSwapTrees(t *testing.T) {
 		}
 	}
 
-	testHeap.swapTrees(copyHeap)
+	testHeap.swapTrees(&copyHeap)
 
 	for i := 0; i < 10; i++ {
 		if copyHeap.Tree[i] != testHeap.Tree[i] {

--- a/shared/binheap_iface.go
+++ b/shared/binheap_iface.go
@@ -1,0 +1,32 @@
+package shared
+
+type BinHeap interface {
+	// Return a copy of the current BinHeap
+	// Copy() BinHeap
+	// NOTE: Copy() is disregarded, but needs to be implemented. It
+	// seems that, as a contractual obligation, interfaces in golang
+	// aren't working optimally and can't return the interface type.
+	// MinNode Returns the root node.
+	// NOTE: This is a minimum binheap.
+	MinNode() *Node
+	// Insert inserts a new BinHeapNode into the BinHeap.
+	// Moreover, if no realloc strategy is declared, it returns the
+	// node to the caller. Verify correct insertion against `nil`.
+	Insert(*Node) *Node
+	// EvictMinNode removes the root node.
+	EvictMinNode() *Node
+	// Peek views the node at specified index.
+	// Errors are only returned if index is not existing in BinHeap
+	Peek(int) (*Node, error)
+	// Checks if the binheap is empty.
+	IsEmpty() bool
+	// Reallocate the size for the binheap.
+	// NOTE: If binheap size goes down, the implementation **ought** to
+	// evict according to however the implementation sees fit.
+	ReAllocate(int)
+	UpdateNodeTimeout(string) *Node
+	Get(string) (*Node, bool)
+	// NOTE: Percolate methods are not required, as a ring-buffer
+	// implementation will allow for non-tree-based operations for the
+	// binheap.
+}


### PR DESCRIPTION
ADD:
  - binheap_iface.go Declares the interface that binary heaps are contractually
    obligated to maintain.