### PR TITLE
Fixes #152 (Add interfaces to all BF libraries)

### DIFF
--- a/bloomfilter/bitset.go
+++ b/bloomfilter/bitset.go
@@ -5,30 +5,38 @@ import (
 	"log"
 )
 
-// Bitset is a simple wrapper around the willf bitset library.
-type Bitset struct {
+type Bitset interface {
+	Add(uint)
+	Contains(uint) bool
+	ToString() string
+	FromString(string)
+	Compare(interface{}) bool
+}
+
+// WFBitset is a simple wrapper around the willf bitset library.
+type WFBitset struct {
 	BS *bitset.BitSet
 }
 
-// NewBitset constructs a new bitset to be used with bloom filters.
-func NewBitset(maxSize uint) *Bitset {
-	return &Bitset{
+// NewWFBitset constructs a new bitset to be used with bloom filters.
+func NewWFBitset(maxSize uint) *WFBitset {
+	return &WFBitset{
 		bitset.New(maxSize),
 	}
 }
 
 // Add handles adding a new hashed index into the bitset.
-func (b *Bitset) Add(index uint) {
+func (b *WFBitset) Add(index uint) {
 	b.BS.Set(index)
 }
 
 // Contains verifies if a hash index is actually in the bitset or not.
-func (b *Bitset) Contains(index uint) bool {
+func (b *WFBitset) Contains(index uint) bool {
 	return b.BS.Test(index)
 }
 
 // ToString handles converting the bitset to a RLE usable string.
-func (b *Bitset) ToString() string {
+func (b *WFBitset) ToString() string {
 	json, err := b.BS.MarshalJSON()
 	if err != nil {
 		panic(err)
@@ -39,9 +47,13 @@ func (b *Bitset) ToString() string {
 
 // FromString handles converting a (valid json) string to a valid underlying
 // bitset.
-func (b *Bitset) FromString(inputString string) {
+func (b *WFBitset) FromString(inputString string) {
 	err := b.BS.UnmarshalJSON([]byte(inputString))
 	if err != nil {
 		log.Println("Invalid bloomfilter received: ", err)
 	}
+}
+
+func (b *WFBitset) Compare(compareTo interface{}) bool {
+	return b.BS.Equal(compareTo.(*WFBitset).BS)
 }

--- a/bloomfilter/bloom.go
+++ b/bloomfilter/bloom.go
@@ -9,18 +9,26 @@ import (
 	"math"
 )
 
-type BloomFilter struct {
+type BloomFilter interface {
+	AddKey(key []byte) (bool, []uint)
+	HasKey(key []byte) (bool, []uint)
+	Serialize() string
+	GetMaxSize() uint
+}
+
+
+type SimpleBloomFilter struct {
 	// The maximum size for the bloom filter
-	MaxSize uint
+	maxSize uint
 	// Total number of hashing functions
 	HashFunctions uint
 	Filter        Bitset
 	HashCache     *olilib_lru.LRUCacheInt32Array
 }
 
-// New Returns a pointer to a newly allocated `BloomFilter` object
-func New(maxSize uint, hashFuns uint) *BloomFilter {
-	return &BloomFilter{
+// New Returns a pointer to a newly allocated `SimpleBloomFilter` object
+func NewSimpleBF(maxSize uint, hashFuns uint) *SimpleBloomFilter {
+	return &SimpleBloomFilter{
 		maxSize,
 		hashFuns,
 		NewWFBitset(maxSize),
@@ -31,13 +39,18 @@ func New(maxSize uint, hashFuns uint) *BloomFilter {
 // NewByFailRate allows generation of a bloom filter with a pre-conceived
 // amount of items and a false-positive failure rate. We calculate our bloom
 // filter bounds and generate the new bloom filter this way.
-func NewByFailRate(items uint, probability float64) *BloomFilter {
+func NewByFailRate(items uint, probability float64) *SimpleBloomFilter {
 	m, k := estimateBounds(items, probability)
-	return New(m, k)
+	return NewSimpleBF(m, k)
+}
+
+// GetMaxSize returns the max size. Just an ugly getter.
+func (bf *SimpleBloomFilter) GetMaxSize() uint {
+	return bf.maxSize
 }
 
 // AddKey Adds a new key to the bloom filter
-func (bf *BloomFilter) AddKey(key []byte) (bool, []uint) {
+func (bf *SimpleBloomFilter) AddKey(key []byte) (bool, []uint) {
 	hasKey, hashIndexes := bf.HasKey(key)
 	if !hasKey {
 		hashIndexes = bf.hashKey(key)
@@ -51,7 +64,7 @@ func (bf *BloomFilter) AddKey(key []byte) (bool, []uint) {
 }
 
 // HasKey verifies if a key is or isn't in the bloom filter.
-func (bf *BloomFilter) HasKey(key []byte) (bool, []uint) {
+func (bf *SimpleBloomFilter) HasKey(key []byte) (bool, []uint) {
 	hashIndexes := bf.hashKey(key)
 
 	for _, element := range hashIndexes {
@@ -67,13 +80,13 @@ func (bf *BloomFilter) HasKey(key []byte) (bool, []uint) {
 
 // ConvertToString handles conversion of a bloom filter to a string. Moreover,
 // it enforces RLE encoding, so that fewer bytes are transferred per request.
-func (bf *BloomFilter) ConvertToString() string {
+func (bf *SimpleBloomFilter) Serialize() string {
 	return Encode(bf.Filter.ToString())
 }
 
 // ConvertStringToBF Decodes the RLE'd bloom filter and then converts it to
 // an actual bloom filter in-memory.
-func ConvertStringtoBF(inputString string, maxSize uint) (*BloomFilter, error) {
+func Deserialize(inputString string, maxSize uint) (*SimpleBloomFilter, error) {
 	bf := NewByFailRate(maxSize, 0.01)
 
 	sz := fmt.Sprintf("\"%s=\"", Decode(inputString))
@@ -117,11 +130,11 @@ func calculateHash(key []byte, offSet int) uint {
 
 // hashKey Takes a string in as an argument and hashes it several times to
 // create usable indexes for the bloom filter.
-func (bf *BloomFilter) hashKey(key []byte) []uint {
+func (bf *SimpleBloomFilter) hashKey(key []byte) []uint {
 	hashes := make([]uint, bf.HashFunctions)
 
 	for index := range hashes {
-		hashes[index] = calculateHash(key, index) % uint(bf.MaxSize)
+		hashes[index] = calculateHash(key, index) % uint(bf.GetMaxSize())
 	}
 
 	return hashes

--- a/bloomfilter/bloom.go
+++ b/bloomfilter/bloom.go
@@ -3,8 +3,8 @@ package bloomfilter
 import (
 	"fmt"
 	"github.com/GrappigPanda/Olivia/lru_cache"
-    "github.com/spaolacci/murmur3"
-    "github.com/mtchavez/jenkins"
+	"github.com/spaolacci/murmur3"
+	"github.com/mtchavez/jenkins"
 	"hash/fnv"
 	"math"
 )
@@ -14,7 +14,7 @@ type BloomFilter struct {
 	MaxSize uint
 	// Total number of hashing functions
 	HashFunctions uint
-	Filter        *Bitset
+	Filter        Bitset
 	HashCache     *olilib_lru.LRUCacheInt32Array
 }
 
@@ -23,7 +23,7 @@ func New(maxSize uint, hashFuns uint) *BloomFilter {
 	return &BloomFilter{
 		maxSize,
 		hashFuns,
-		NewBitset(maxSize),
+		NewWFBitset(maxSize),
 		olilib_lru.NewInt32Array(int((float64(maxSize) * float64(0.1)))),
 	}
 }
@@ -120,7 +120,7 @@ func calculateHash(key []byte, offSet int) uint {
 func (bf *BloomFilter) hashKey(key []byte) []uint {
 	hashes := make([]uint, bf.HashFunctions)
 
-	for index, _ := range hashes {
+	for index := range hashes {
 		hashes[index] = calculateHash(key, index) % uint(bf.MaxSize)
 	}
 

--- a/bloomfilter/bloom_test.go
+++ b/bloomfilter/bloom_test.go
@@ -8,16 +8,16 @@ import (
 var CONFIG = config.ReadConfig()
 
 func TestNewBloomFilter(t *testing.T) {
-	expectedReturn := BloomFilter{
-		MaxSize:       uint(CONFIG.BloomfilterSize),
+	expectedReturn := SimpleBloomFilter{
+		maxSize:       uint(CONFIG.BloomfilterSize),
 		HashFunctions: 3,
 		Filter:        NewWFBitset(10000),
 	}
 
-	result := New(uint(CONFIG.BloomfilterSize), 3)
+	result := NewSimpleBF(uint(CONFIG.BloomfilterSize), 3)
 
-	if expectedReturn.MaxSize != result.MaxSize {
-		t.Fatalf("Expected %v got %v", expectedReturn.MaxSize, result.MaxSize)
+	if expectedReturn.GetMaxSize() != result.GetMaxSize() {
+		t.Fatalf("Expected %v got %v", expectedReturn.GetMaxSize(), result.GetMaxSize())
 	}
 
 	if expectedReturn.HashFunctions != result.HashFunctions {
@@ -26,16 +26,16 @@ func TestNewBloomFilter(t *testing.T) {
 }
 
 func TestNewBloomFilterByFailRate(t *testing.T) {
-	expectedReturn := BloomFilter{
-		MaxSize:       9585,
+	expectedReturn := SimpleBloomFilter{
+		maxSize:       9585,
 		HashFunctions: 3,
 		Filter:        NewWFBitset(10000),
 	}
 
 	result := NewByFailRate(uint(CONFIG.BloomfilterSize), 0.01)
 
-	if expectedReturn.MaxSize != result.MaxSize {
-		t.Fatalf("Expected %v got %v", expectedReturn.MaxSize, result.MaxSize)
+	if expectedReturn.GetMaxSize() != result.GetMaxSize() {
+		t.Fatalf("Expected %v got %v", expectedReturn.GetMaxSize(), result.GetMaxSize())
 	}
 }
 
@@ -73,9 +73,9 @@ func TestHasKeyFailNoKey(t *testing.T) {
 func TestConvertToString(t *testing.T) {
 	bf := NewByFailRate(uint(CONFIG.BloomfilterSize), 0.01)
 
-	new_bf_str := bf.ConvertToString()
+	new_bf_str := bf.Serialize()
 
-	new_bf, err := ConvertStringtoBF(new_bf_str, uint(CONFIG.BloomfilterSize))
+	new_bf, err := Deserialize(new_bf_str, uint(CONFIG.BloomfilterSize))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -94,9 +94,9 @@ func TestConvertWithContainedValues(t *testing.T) {
 	bf.AddKey([]byte("key3"))
 	bf.AddKey([]byte("key4"))
 
-	new_bf_str := bf.ConvertToString()
+	new_bf_str := bf.Serialize()
 
-	new_bf, err := ConvertStringtoBF(new_bf_str, uint(CONFIG.BloomfilterSize))
+	new_bf, err := Deserialize(new_bf_str, uint(CONFIG.BloomfilterSize))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/bloomfilter/bloom_test.go
+++ b/bloomfilter/bloom_test.go
@@ -11,7 +11,7 @@ func TestNewBloomFilter(t *testing.T) {
 	expectedReturn := BloomFilter{
 		MaxSize:       uint(CONFIG.BloomfilterSize),
 		HashFunctions: 3,
-		Filter:        new(Bitset),
+		Filter:        NewWFBitset(10000),
 	}
 
 	result := New(uint(CONFIG.BloomfilterSize), 3)
@@ -29,7 +29,7 @@ func TestNewBloomFilterByFailRate(t *testing.T) {
 	expectedReturn := BloomFilter{
 		MaxSize:       9585,
 		HashFunctions: 3,
-		Filter:        new(Bitset),
+		Filter:        NewWFBitset(10000),
 	}
 
 	result := NewByFailRate(uint(CONFIG.BloomfilterSize), 0.01)
@@ -80,7 +80,7 @@ func TestConvertToString(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	if !new_bf.Filter.BS.Equal(bf.Filter.BS) {
+	if !new_bf.Filter.Compare(bf.Filter) {
 		t.Fatalf("Two bfs are not equal")
 	}
 }
@@ -106,7 +106,7 @@ func TestConvertWithContainedValues(t *testing.T) {
 		t.Fatalf("new_bf doesnt have key1!")
 	}
 
-	if !new_bf.Filter.BS.Equal(bf.Filter.BS) {
+	if !new_bf.Filter.Compare(bf.Filter) {
 		t.Fatalf("Two bfs are not equal")
 	}
 }

--- a/dht/peer.go
+++ b/dht/peer.go
@@ -34,7 +34,7 @@ type Peer struct {
 	Status       State
 	Conn         *net.Conn
 	IPPort       string
-	BloomFilter  *bloomfilter.BloomFilter
+	BloomFilter  bloomfilter.BloomFilter
 	MessageBus   *message_handler.MessageHandler
 	failureCount int
 	sync.Mutex
@@ -148,10 +148,10 @@ func (p *Peer) GetBloomFilter() {
 			return
 		}
 
-		for k, _ := range responseData.Args {
+		for k := range responseData.Args {
 			p.Lock()
 			defer p.Unlock()
-			bf, err := bloomfilter.ConvertStringtoBF(k, p.BloomFilter.MaxSize)
+			bf, err := bloomfilter.Deserialize(k, p.BloomFilter.GetMaxSize())
 			if err != nil {
 				p.BloomFilter = nil
 			}

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -18,7 +18,7 @@ import (
 type ConnectionCtx struct {
 	Parser      *parser.Parser
 	Cache       *cache.Cache
-	Bloomfilter *bloomfilter.BloomFilter
+	Bloomfilter bloomfilter.BloomFilter
 	MessageBus  *message_handler.MessageHandler
 	PeerList    *dht.PeerList
 }

--- a/network/incoming/incoming_network_test.go
+++ b/network/incoming/incoming_network_test.go
@@ -42,7 +42,7 @@ func TestGetBloomfilter(t *testing.T) {
 
 	bf_str := strings.Split(str, " ")
 	inputStr := strings.TrimSpace(bf_str[1])
-	_, err := bloomfilter.ConvertStringtoBF(inputStr, uint(CONFIG.BloomfilterSize))
+	_, err := bloomfilter.Deserialize(inputStr, uint(CONFIG.BloomfilterSize))
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -74,21 +74,21 @@ func TestSetKeyUpdatesBloomFilter(t *testing.T) {
 
 	bf_str := strings.Split(str, " ")
 	inputStr := strings.TrimSpace(bf_str[1])
-	bf, err := bloomfilter.ConvertStringtoBF(inputStr, uint(CONFIG.BloomfilterSize))
+	bf, err := bloomfilter.Deserialize(inputStr, uint(CONFIG.BloomfilterSize))
 	if err != nil {
 		t.Errorf("%v", err)
 	}
 
 	if ok, _ := bf.HasKey([]byte("key1")); !ok {
-		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.Serialize())
 	}
 
 	if ok, _ := bf.HasKey([]byte("key2")); !ok {
-		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.Serialize())
 	}
 
 	if ok, _ := bf.HasKey([]byte("key3")); !ok {
-		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.ConvertToString())
+		t.Errorf("Bloom filter doesn't contain correct keys %v", bf.Serialize())
 	}
 }
 

--- a/network/incoming/language_map.go
+++ b/network/incoming/language_map.go
@@ -72,7 +72,7 @@ func (ctx *ConnectionCtx) ExecuteCommand(requestData parser.CommandData) string 
 
 				retVals[index] = fmt.Sprintf("%s:%s", k, v)
 				index++
-				(*ctx.Bloomfilter).AddKey([]byte(k))
+				ctx.Bloomfilter.AddKey([]byte(k))
 			}
 
 			return createResponse(command, retVals, requestData.Hash)
@@ -154,7 +154,7 @@ func (ctx *ConnectionCtx) handleRequest(requestData parser.CommandData) string {
 	switch strings.ToUpper(requestItem) {
 	case "BLOOMFILTER":
 		{
-			bfString := (*ctx.Bloomfilter).ConvertToString()
+			bfString := ctx.Bloomfilter.Serialize()
 			return createResponse(
 				requestData.Command,
 				[]string{bfString},
@@ -166,7 +166,7 @@ func (ctx *ConnectionCtx) handleRequest(requestData parser.CommandData) string {
 			(*ctx.PeerList).AddPeer((*requestData.Conn).RemoteAddr().String())
 			return createResponse(
 				requestData.Command,
-				[]string{(*ctx.Bloomfilter).ConvertToString()},
+				[]string{ctx.Bloomfilter.Serialize()},
 				"",
 			)
 		}

--- a/network/incoming/language_map_test.go
+++ b/network/incoming/language_map_test.go
@@ -122,7 +122,7 @@ func TestRequestBloomFilter(t *testing.T) {
 		t.Fatalf("newBloomfilter doesnt have key1!")
 	}
 
-	if !bf.Filter.BS.Equal(newBloomfilter.Filter.BS) {
+	if !bf.Filter.Compare(newBloomfilter.Filter) {
 		t.Fatalf("Two bfs are not equal")
 	}
 }

--- a/network/incoming/language_map_test.go
+++ b/network/incoming/language_map_test.go
@@ -112,7 +112,7 @@ func TestRequestBloomFilter(t *testing.T) {
 		break
 	}
 
-	newBloomfilter, err := bloomfilter.ConvertStringtoBF(bfToParse, uint(CONFIG.BloomfilterSize))
+	newBloomfilter, err := bloomfilter.Deserialize(bfToParse, uint(CONFIG.BloomfilterSize))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
ADD:
  - bloomfilter/bitset.go Now has an interface `Bitset` whereas the previous
    implementation has been replaced by `WFBitset` whcih is merely a struct
    that implements the `Bitset` interface. All other changes are accompanying
    this particular change.