### PR TITLE
Fixes #154

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Olivia.exe
 Olivia.exe*
 OliviaNode
 OliviaServer
+main

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ go:
 - 1.7
 
 script:
-- go test ./... -cover -race
+- go test ./... -cover -race -timeout 30s

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@
 Olivia is essentially a distributed hash table that I built to test out some
 weird ideas I've had about Go and distributed programming that I've had.
 
-## Is it production ready?
-I'd definitely consider this **not** production ready. I typically approach
-personal projects in two phases: the initial naive phase, where I implement
-things in the most natural (for me) way; and the improvement phase, where I
-exchange naive solutions for more optimal solutions. I'm heavily entrenched
-into the naive phase, so while I'm getting to the optimal solution phase, I'm
-not there yet.
-
 ## What is Olivia
 Olivia is essentially just a distributed hash table with added goodies.
 From early on, I wanted to use bloomfilters to enhance lookup speed
@@ -38,7 +30,7 @@ Real quick and easy steps to run a node:
 ```
   1. git clone https://github.com/GrappigPanda/Olivia
   2. cd Olivia
-  3. build/install_deps.sh
+  3. go get ./...
   4. go build
   5. ./Olivia
 ```

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -10,7 +10,7 @@ import (
 // TODO(ian): Replace this with something else
 // Cache is actually just a map[string]string. Don't tell anyone.
 type Cache struct {
-	Cache   *map[string]string
+	cache   *map[string]string
 	binHeap *binheap.Heap
 	sync.Mutex
 }
@@ -19,7 +19,7 @@ type Cache struct {
 func NewCache() *Cache {
 	cacheMap := make(map[string]string)
 	return &Cache{
-		Cache:   &cacheMap,
+		cache:   &cacheMap,
 		binHeap: binheap.NewHeapReallocate(100),
 	}
 }
@@ -28,7 +28,7 @@ func NewCache() *Cache {
 // from the ReadCache which is for copy-on-write optimizations so that
 // reading doesn't lock the cache.
 func (c *Cache) Get(key string) (string, error) {
-	if value, ok := (*c.Cache)[key]; !ok {
+	if value, ok := (*c.cache)[key]; !ok {
 		return "", fmt.Errorf("Key not found in cache")
 	} else {
 		return value, nil
@@ -38,8 +38,8 @@ func (c *Cache) Get(key string) (string, error) {
 // copyCache handles creating a copy of the cache
 func (c *Cache) copyCache() {
 	c.Lock()
-	for k, v := range *c.Cache {
-		(*c.Cache)[k] = v
+	for k, v := range *c.cache {
+		(*c.cache)[k] = v
 	}
 	c.Unlock()
 }
@@ -48,7 +48,7 @@ func (c *Cache) copyCache() {
 // ReadCache.
 func (c *Cache) Set(key string, value string) error {
 	c.Lock()
-	(*c.Cache)[key] = value
+	(*c.cache)[key] = value
 	c.Unlock()
 
 	c.copyCache()
@@ -99,6 +99,6 @@ func (c *Cache) EvictExpiredkeys(expirationDate time.Time) {
 }
 
 func (c *Cache) expireKey(key string) {
-	delete(*c.Cache, key)
+	delete(*c.cache, key)
 	// TODO(ian): We need to also remove the the key from the binary heap.
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -41,7 +41,7 @@ func NewCache(mh *message_handler.MessageHandler, config *config.Cfg) *Cache {
 		}
 
 		err := cache.PeerList.ConnectAllPeers()
-		if err != nil {
+		if err != nil && !config.IsTesting {
 			for err != nil {
 				log.Println("Sleeping for 60 seconds and attempting to reconnect")
 				time.Sleep(time.Second * 60)

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestNewCache(t *testing.T) {
-	_ = NewCache()
+	_ = NewCache(nil, nil)
 }
 
 func TestSetGet(t *testing.T) {
-	cache := NewCache()
+	cache := NewCache(nil, nil)
 
 	key := "TestKey"
 	cache.Set(key, "1024")
@@ -34,7 +34,7 @@ func TestSetGet(t *testing.T) {
 }
 
 func TestCache_SetExpiration(t *testing.T) {
-	cache := NewCache()
+	cache := NewCache(nil, nil)
 
 	key := "TestKey"
 	testValue := "1024"

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -15,7 +15,7 @@ func TestSetGet(t *testing.T) {
 
 	key := "TestKey"
 	cache.Set(key, "1024")
-	if value, ok := (*cache.Cache)[key]; !ok || value != "1024" {
+	if value, err := cache.Get(key); err != nil || value != "1024" {
 		t.Fatalf("expected %v, got %v", "1024", value)
 		t.Fatalf("Expected True, got False")
 	}
@@ -23,9 +23,8 @@ func TestSetGet(t *testing.T) {
 	secondValue, err := cache.Get(key)
 	if err != nil {
 		t.Fatalf(
-			"Got error from GETing key: %v, %v",
+			"Got error from GETing key: %v",
 			err,
-			(*cache.Cache),
 		)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Cfg struct {
 	BaseNode          bool
 	RemotePeers       []string
 	ListenPort        int
+	IsTesting         bool
 }
 
 // ReadConfig handles opening a file and creating a config object for use
@@ -44,5 +45,6 @@ func ReadConfig() *Cfg {
 		viper.GetBool("basenode"),
 		viper.GetStringSlice("remotepeers"),
 		viper.GetInt("listenport"),
+		false,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,9 +10,10 @@ import (
 func Init() {
 	config := config.ReadConfig()
 
-	internalCache := cache.NewCache()
-
 	messageHandler := message_handler.NewMessageHandler()
+
+	internalCache := cache.NewCache(messageHandler, config)
+
 	networkHandler.StartIncomingNetwork(
 		messageHandler,
 		internalCache,

--- a/network/incoming/incoming_network.go
+++ b/network/incoming/incoming_network.go
@@ -6,7 +6,6 @@ import (
 	"github.com/GrappigPanda/Olivia/bloomfilter"
 	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/config"
-	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/network/message_handler"
 	"github.com/GrappigPanda/Olivia/parser"
 	"log"
@@ -19,8 +18,6 @@ type ConnectionCtx struct {
 	Parser      *parser.Parser
 	Cache       *cache.Cache
 	Bloomfilter bloomfilter.BloomFilter
-	MessageBus  *message_handler.MessageHandler
-	PeerList    *dht.PeerList
 }
 
 // StartNetworkRouter initializes everything necessary for our incoming network
@@ -28,7 +25,6 @@ type ConnectionCtx struct {
 func StartNetworkRouter(
 	mh *message_handler.MessageHandler,
 	cache *cache.Cache,
-	peerList *dht.PeerList,
 	config *config.Cfg,
 ) chan struct{} {
 	stopchan := make(chan struct{})
@@ -49,8 +45,6 @@ func StartNetworkRouter(
 			parser.NewParser(mh),
 			cache,
 			bf,
-			mh,
-			peerList,
 		}
 
 		log.Println("Starting connection router!")

--- a/network/incoming/incoming_network_test.go
+++ b/network/incoming/incoming_network_test.go
@@ -98,6 +98,7 @@ func TestGetKeyFromRemoteNode(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	mh := message_handler.NewMessageHandler()
+	CONFIG.IsTesting = true
 	cache := cache.NewCache(mh, CONFIG)
 	config := config.ReadConfig()
 	stopchan := StartNetworkRouter(mh, cache, config)

--- a/network/incoming/incoming_network_test.go
+++ b/network/incoming/incoming_network_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/GrappigPanda/Olivia/bloomfilter"
 	"github.com/GrappigPanda/Olivia/cache"
 	"github.com/GrappigPanda/Olivia/config"
-	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/network/message_handler"
 	"net"
 	"os"
@@ -99,10 +98,9 @@ func TestGetKeyFromRemoteNode(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	mh := message_handler.NewMessageHandler()
-	cache := cache.NewCache()
-	peerList := dht.NewPeerList(mh, *CONFIG)
+	cache := cache.NewCache(mh, CONFIG)
 	config := config.ReadConfig()
-	stopchan := StartNetworkRouter(mh, cache, peerList, config)
+	stopchan := StartNetworkRouter(mh, cache, config)
 
 	os.Exit(m.Run())
 

--- a/network/incoming/language_map.go
+++ b/network/incoming/language_map.go
@@ -29,8 +29,8 @@ func (ctx *ConnectionCtx) ExecuteCommand(requestData parser.CommandData) string 
 			index := 0
 			responseChannel := make(chan string)
 			for k := range args {
-				val, ok := (*ctx.Cache.Cache)[k]
-				if ok {
+				val, err := ctx.Cache.Get(k)
+				if err == nil {
 					retVals[index] = fmt.Sprintf("%s:%s", k, val)
 					index++
 				} else {
@@ -68,7 +68,7 @@ func (ctx *ConnectionCtx) ExecuteCommand(requestData parser.CommandData) string 
 
 			index := 0
 			for k, v := range args {
-				(*ctx.Cache.Cache)[k] = v
+				ctx.Cache.Set(k, v)
 
 				retVals[index] = fmt.Sprintf("%s:%s", k, v)
 				index++

--- a/network/incoming/language_map.go
+++ b/network/incoming/language_map.go
@@ -3,7 +3,6 @@ package incomingNetwork
 import (
 	"bytes"
 	"fmt"
-	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/parser"
 	"log"
 	"strconv"
@@ -27,36 +26,11 @@ func (ctx *ConnectionCtx) ExecuteCommand(requestData parser.CommandData) string 
 			retVals := make([]string, len(args))
 
 			index := 0
-			responseChannel := make(chan string)
 			for k := range args {
 				val, err := ctx.Cache.Get(k)
 				if err == nil {
 					retVals[index] = fmt.Sprintf("%s:%s", k, val)
 					index++
-				} else {
-					for _, peer := range ctx.PeerList.Peers {
-						if peer == nil || peer.Status == dht.Timeout || peer.Status == dht.Disconnected {
-							continue
-						}
-
-						peer.SendRequest(
-							fmt.Sprintf("GET %s", k),
-							responseChannel,
-							ctx.MessageBus,
-						)
-
-						value := <-responseChannel
-						if value != "" {
-							splitString := strings.Split(value, " ")
-							splitString = strings.Split(splitString[1], ":")
-							if len(splitString) > 1 {
-								retVals[index] = fmt.Sprintf("%s:%s", k, splitString[1])
-							} else {
-								retVals[index] = fmt.Sprintf("%s:%s", k, "")
-							}
-							index++
-						}
-					}
 				}
 			}
 
@@ -163,7 +137,7 @@ func (ctx *ConnectionCtx) handleRequest(requestData parser.CommandData) string {
 		}
 	case "CONNECT":
 		{
-			(*ctx.PeerList).AddPeer((*requestData.Conn).RemoteAddr().String())
+			ctx.Cache.AddPeer((*requestData.Conn).RemoteAddr().String())
 			return createResponse(
 				requestData.Command,
 				[]string{ctx.Bloomfilter.Serialize()},
@@ -172,67 +146,11 @@ func (ctx *ConnectionCtx) handleRequest(requestData parser.CommandData) string {
 		}
 	case "PEERS":
 		{
-			count := 0
-			outString := fmt.Sprintf("%s:FULFILLED ", requestData.Hash)
-
-			for _, peer := range ctx.PeerList.Peers {
-				if peer == nil {
-					continue
-				}
-
-				if count == 0 {
-					outString = fmt.Sprintf(
-						"%s%s",
-						outString,
-						peer.IPPort,
-					)
-
-				} else {
-					outString = fmt.Sprintf(
-						"%s,%s",
-						outString,
-						peer.IPPort,
-					)
-
-				}
-			}
-
-			for _, peer := range ctx.PeerList.BackupPeers {
-				if peer == nil {
-					continue
-				}
-
-				outString = fmt.Sprintf(
-					"%s,%s",
-					outString,
-					peer.IPPort,
-				)
-			}
-
-			outString = fmt.Sprintf(
-				"%s\n",
-				outString,
-			)
-
-			return outString
+			return ctx.Cache.ListPeers(requestData.Hash)
 		}
 	case "DISCONNECT":
 		{
-			outString := "Peer not found in peer list."
-			for _, peer := range ctx.PeerList.Peers {
-				if peer.IPPort != (*requestData.Conn).RemoteAddr().String() {
-					continue
-				}
-
-				if peer != nil && peer.Status == dht.Connected {
-					peer.Disconnect()
-					outString = "Peer has been disconnected."
-				}
-
-				// TODO(ian): Connect a backup node after one node has forced itself to be evicted.
-			}
-
-			return outString
+			return ctx.Cache.DisconnectPeer((*requestData.Conn).RemoteAddr().String())
 		}
 	}
 

--- a/network/incoming/language_map_test.go
+++ b/network/incoming/language_map_test.go
@@ -3,7 +3,6 @@ package incomingNetwork
 import (
 	"github.com/GrappigPanda/Olivia/bloomfilter"
 	"github.com/GrappigPanda/Olivia/cache"
-	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/network/message_handler"
 	"github.com/GrappigPanda/Olivia/parser"
 	"testing"
@@ -13,10 +12,8 @@ var MESSAGEBUS = message_handler.NewMessageHandler()
 
 var CTX = &ConnectionCtx{
 	nil,
-	cache.NewCache(),
+	cache.NewCache(nil, nil),
 	bloomfilter.NewByFailRate(1000, 0.01),
-	MESSAGEBUS,
-	dht.NewPeerList(MESSAGEBUS, *CONFIG),
 }
 
 func TestExecuteGetAllSucceed(t *testing.T) {
@@ -94,8 +91,6 @@ func TestRequestBloomFilter(t *testing.T) {
 		nil,
 		nil,
 		bf,
-		nil,
-		nil,
 	}
 
 	command := parser.CommandData{"hash", "REQUEST", map[string]string{"bloomfilter": ""}, make(map[string]string), nil}

--- a/network/incoming/language_map_test.go
+++ b/network/incoming/language_map_test.go
@@ -23,8 +23,8 @@ func TestExecuteGetAllSucceed(t *testing.T) {
 	expectedReturn := "hash:GOT key1:test1,key2:test14\n"
 	expectedReturn2 := "hash:GOT key2:test14,key1:test1\n"
 
-	(*CTX.Cache.Cache)["key1"] = "test1"
-	(*CTX.Cache.Cache)["key2"] = "test14"
+	CTX.Cache.Set("key1", "test1")
+	CTX.Cache.Set("key2", "test14")
 
 	command := parser.CommandData{"hash", "GET", map[string]string{"key1": "", "key2": ""}, make(map[string]string), nil}
 	result := CTX.ExecuteCommand(command)
@@ -40,8 +40,8 @@ func TestExecuteGetAllSkipNonexistingKey(t *testing.T) {
 	expectedReturn := "hash:GOT key1:test1,key2:test14\n"
 	expectedReturn2 := "hash:GOT key2:test14,key1:test1\n"
 
-	(*CTX.Cache.Cache)["key1"] = "test1"
-	(*CTX.Cache.Cache)["key2"] = "test14"
+	CTX.Cache.Set("key1", "test1")
+	CTX.Cache.Set("key2", "test14")
 
 	command := parser.CommandData{"hash", "GET", map[string]string{"key1": "", "key2": ""}, make(map[string]string), nil}
 	result := CTX.ExecuteCommand(command)

--- a/network/network_handler.go
+++ b/network/network_handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/GrappigPanda/Olivia/dht"
 	"github.com/GrappigPanda/Olivia/network/incoming"
 	"github.com/GrappigPanda/Olivia/network/message_handler"
-	"log"
 	"time"
 ) // executeRepeatedly Allows repeated calls to any function which doesn't accept
 // arguments. Allows for remote stopping of the execution and passing back
@@ -105,35 +104,18 @@ func StartIncomingNetwork(
 	config *config.Cfg,
 	mainStopChan chan struct{},
 ) {
-	peerList := dht.NewPeerList(mh, *config)
-
 	// BaseNode==True signifies that we're not expecting to connect to any
 	// remote nodes on connection, so if it's false, we'll skip that step and
 	// just wait for incoming connections.
 	if !config.BaseNode {
-		for index, peerIP := range config.RemotePeers {
-			peer := dht.NewPeerByIP(peerIP, mh, *config)
-			peerList.Peers[index] = peer
-			(*peerList.PeerMap)[peerIP] = true
-		}
-
-		err := peerList.ConnectAllPeers()
-		if err != nil {
-			for err != nil {
-				log.Println("Sleeping for 60 seconds and attempting to reconnect")
-				time.Sleep(time.Second * 60)
-				err = peerList.ConnectAllPeers()
-			}
-		}
-
 		Heartbeat(
 			time.Duration(config.HeartbeatInterval)*time.Millisecond,
 			time.Duration(config.HeartbeatLoop)*time.Second,
-			peerList,
+			cache.PeerList,
 		)
 	}
 
-	networkRouterStopChan := incomingNetwork.StartNetworkRouter(mh, cache, peerList, config)
+	networkRouterStopChan := incomingNetwork.StartNetworkRouter(mh, cache, cache.PeerList, config)
 	// TODO(ian): Clean up this for statement, it's technical debt.
 	for {
 		select {

--- a/network/network_handler.go
+++ b/network/network_handler.go
@@ -115,7 +115,7 @@ func StartIncomingNetwork(
 		)
 	}
 
-	networkRouterStopChan := incomingNetwork.StartNetworkRouter(mh, cache, cache.PeerList, config)
+	networkRouterStopChan := incomingNetwork.StartNetworkRouter(mh, cache, config)
 	// TODO(ian): Clean up this for statement, it's technical debt.
 	for {
 		select {


### PR DESCRIPTION
ADD:
  - .gitignore now ignores the binary produced by `go build *.go` (main)

CHANGE:
  - cache/cache.go Now doesn't expose the internal `Cache` object and relies on
    callers using the getters/setters.
  - network/incoming/language_map.go Follows changes made in `cache/cache.go`.